### PR TITLE
Fix calendar layout and task filtering

### DIFF
--- a/app/tasks/page.tsx
+++ b/app/tasks/page.tsx
@@ -1,64 +1,69 @@
-"use client"
+"use client";
 
-import { useState, useEffect } from "react"
-import { NewNavbar } from "@/components/new-navbar"
+import { useState, useEffect } from "react";
+import { NewNavbar } from "@/components/new-navbar";
 import {
   Search,
-  Calendar,
-  Plus,
+  Calendar as CalendarIcon,
   Edit,
   Trash2,
   Check,
   MessageSquare,
-  Users,
   User,
-  CheckSquare,
   Link,
   Loader2,
   AlertCircle,
-} from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Progress } from "@/components/ui/progress"
-import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
-import { NewTaskModal } from "@/components/new-task-modal"
-import { EditTaskModal } from "@/components/edit-task-modal"
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
-import { getSupabaseClient } from "@/utils/supabase"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { getUsername, storeUsername } from "@/utils/user-helpers"
-import { useRouter } from "next/navigation"
-import { toast } from "@/components/ui/use-toast"
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { NewTaskModal } from "@/components/new-task-modal";
+import { EditTaskModal } from "@/components/edit-task-modal";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { getSupabaseClient } from "@/utils/supabase";
+import { getUsername, storeUsername } from "@/utils/user-helpers";
+import { useRouter } from "next/navigation";
+import { toast } from "@/components/ui/use-toast";
+import { Calendar } from "@/components/ui/calendar";
 
 // Tipo para usuario con rol
-type UserRole = "admin" | "member"
+type UserRole = "admin" | "member";
 
 // Tipo para una tarea
 interface Task {
-  id: number
-  text: string
-  description?: string
-  assignee: string
-  dueDate: string
-  completed: boolean
-  meeting_id?: number
-  meeting_title?: string
-  priority: "baja" | "media" | "alta"
-  progress: number
-  comments?: { author: string; text: string; date: string }[]
+  id: number;
+  text: string;
+  description?: string;
+  assignee: string;
+  dueDate: string;
+  completed: boolean;
+  meeting_id?: number;
+  meeting_title?: string;
+  priority: "baja" | "media" | "alta";
+  progress: number;
+  comments?: { author: string; text: string; date: string }[];
 }
 
 // Tipo para una reunión
 interface Meeting {
-  id: number
-  title: string
+  id: number;
+  title: string;
+  date?: string;
 }
 
 // Componente para una tarea individual
 const TaskItem = ({ task, userRole, onToggleComplete, onEdit, onDelete }) => {
-  const isOverdue = task.dueDate && new Date(task.dueDate) < new Date() && !task.completed
-  const hasComments = task.comments && task.comments.length > 0
+  const isOverdue =
+    task.dueDate && new Date(task.dueDate) < new Date() && !task.completed;
+  const hasComments = task.comments && task.comments.length > 0;
 
   return (
     <div
@@ -73,7 +78,11 @@ const TaskItem = ({ task, userRole, onToggleComplete, onEdit, onDelete }) => {
       <div className="flex items-start">
         <button
           className={`h-6 w-6 rounded border flex-shrink-0 mr-3 mt-1 flex items-center justify-center ${
-            task.completed ? "bg-green-500 border-green-600" : isOverdue ? "border-red-500" : "border-blue-500"
+            task.completed
+              ? "bg-green-500 border-green-600"
+              : isOverdue
+                ? "border-red-500"
+                : "border-blue-500"
           }`}
           onClick={() => onToggleComplete(task.id)}
         >
@@ -82,19 +91,32 @@ const TaskItem = ({ task, userRole, onToggleComplete, onEdit, onDelete }) => {
 
         <div className="flex-1">
           <div className="flex justify-between">
-            <p className={`${task.completed ? "text-blue-300/70 line-through" : "text-white"}`}>{task.text}</p>
+            <p
+              className={`${task.completed ? "text-blue-300/70 line-through" : "text-white"}`}
+            >
+              {task.text}
+            </p>
           </div>
 
           {task.description && (
-            <p className={`text-sm mt-1 ${task.completed ? "text-blue-300/50" : "text-blue-200/70"}`}>
-              {task.description.length > 100 ? `${task.description.substring(0, 100)}...` : task.description}
+            <p
+              className={`text-sm mt-1 ${task.completed ? "text-blue-300/50" : "text-blue-200/70"}`}
+            >
+              {task.description.length > 100
+                ? `${task.description.substring(0, 100)}...`
+                : task.description}
             </p>
           )}
 
           <div className="mt-2 mb-2">
             <div className="flex items-center gap-2">
-              <Progress value={task.progress} className="h-2 w-full bg-blue-800/50" />
-              <span className="text-xs text-blue-200/70 min-w-10 text-right">{task.progress}%</span>
+              <Progress
+                value={task.progress}
+                className="h-2 w-full bg-blue-800/50"
+              />
+              <span className="text-xs text-blue-200/70 min-w-10 text-right">
+                {task.progress}%
+              </span>
             </div>
           </div>
 
@@ -102,9 +124,18 @@ const TaskItem = ({ task, userRole, onToggleComplete, onEdit, onDelete }) => {
             {/* Fecha límite - Siempre mostrar si existe */}
             {task.dueDate && (
               <div className="flex items-center text-blue-200/70">
-                <Calendar className="h-3.5 w-3.5 mr-1" />
-                <span className={isOverdue ? "text-red-300" : task.completed ? "text-blue-300/50" : "text-blue-200/70"}>
-                  Fecha límite: {task.dueDate.split("T")[0].split("-").reverse().join("/")}
+                <CalendarIcon className="h-3.5 w-3.5 mr-1" />
+                <span
+                  className={
+                    isOverdue
+                      ? "text-red-300"
+                      : task.completed
+                        ? "text-blue-300/50"
+                        : "text-blue-200/70"
+                  }
+                >
+                  Fecha límite:{" "}
+                  {task.dueDate.split("T")[0].split("-").reverse().join("/")}
                 </span>
               </div>
             )}
@@ -112,16 +143,24 @@ const TaskItem = ({ task, userRole, onToggleComplete, onEdit, onDelete }) => {
             <div className="flex items-center text-blue-200/70">
               <span
                 className={`inline-block w-2 h-2 rounded-full mr-1.5 ${
-                  task.priority === "alta" ? "bg-red-500" : task.priority === "media" ? "bg-yellow-500" : "bg-green-500"
+                  task.priority === "alta"
+                    ? "bg-red-500"
+                    : task.priority === "media"
+                      ? "bg-yellow-500"
+                      : "bg-green-500"
                 }`}
               ></span>
-              <span className={task.completed ? "text-blue-300/50" : ""}>Prioridad {task.priority}</span>
+              <span className={task.completed ? "text-blue-300/50" : ""}>
+                Prioridad {task.priority}
+              </span>
             </div>
 
             <div className="flex items-center text-blue-200/70">
               <User className="h-3.5 w-3.5 mr-1" />
               <span className={task.completed ? "text-blue-300/50" : ""}>
-                {task.assignee && task.assignee !== "No asignado" ? `Asignado a: ${task.assignee}` : "Sin asignar"}
+                {task.assignee && task.assignee !== "No asignado"
+                  ? `Asignado a: ${task.assignee}`
+                  : "Sin asignar"}
               </span>
             </div>
 
@@ -139,7 +178,9 @@ const TaskItem = ({ task, userRole, onToggleComplete, onEdit, onDelete }) => {
             {hasComments && (
               <div className="flex items-center text-blue-200/70">
                 <MessageSquare className="h-3.5 w-3.5 mr-1" />
-                <span className="text-blue-300/70">{task.comments.length} comentario(s)</span>
+                <span className="text-blue-300/70">
+                  {task.comments.length} comentario(s)
+                </span>
               </div>
             )}
           </div>
@@ -167,57 +208,127 @@ const TaskItem = ({ task, userRole, onToggleComplete, onEdit, onDelete }) => {
         </div>
       </div>
     </div>
-  )
-}
+  );
+};
+
+// Elemento para mostrar una conversación en la barra lateral
+const ConversationSidebarItem = ({ meeting, isSelected, onSelect }) => {
+  return (
+    <div
+      className={`p-2 rounded cursor-pointer mb-1 border border-blue-700/30 ${
+        isSelected ? "bg-blue-700/40" : "bg-blue-800/30 hover:bg-blue-700/30"
+      }`}
+      onClick={() => onSelect(meeting.id.toString())}
+    >
+      <p className="text-sm text-white">{meeting.title}</p>
+      {meeting.date && (
+        <p className="text-xs text-blue-300/70">
+          {new Date(meeting.date).toLocaleDateString()}
+        </p>
+      )}
+    </div>
+  );
+};
+
+// Calendario para visualizar el estado de las tareas
+const TasksCalendar = ({ tasks }) => {
+  const uniqueDates = (items) =>
+    Array.from(new Set(items.map((t) => t.dueDate))).map((d) => new Date(d));
+
+  const modifiers = {
+    completed: uniqueDates(tasks.filter((t) => t.completed && t.dueDate)),
+    overdue: uniqueDates(
+      tasks.filter(
+        (t) => !t.completed && t.dueDate && new Date(t.dueDate) < new Date(),
+      ),
+    ),
+    inProgress: uniqueDates(
+      tasks.filter(
+        (t) =>
+          !t.completed &&
+          t.dueDate &&
+          t.progress > 0 &&
+          t.progress < 100 &&
+          new Date(t.dueDate) >= new Date(),
+      ),
+    ),
+    pending: uniqueDates(
+      tasks.filter(
+        (t) =>
+          !t.completed &&
+          t.dueDate &&
+          t.progress === 0 &&
+          new Date(t.dueDate) >= new Date(),
+      ),
+    ),
+  };
+
+  return (
+    <Calendar
+      mode="single"
+      weekStartsOn={1}
+      modifiers={modifiers}
+      modifiersClassNames={{
+        completed: "bg-green-600 text-white hover:bg-green-600",
+        overdue: "bg-red-600 text-white hover:bg-red-600",
+        inProgress: "bg-yellow-500 text-black hover:bg-yellow-500",
+        pending: "bg-orange-500 text-white hover:bg-orange-500",
+      }}
+      className="rounded-lg border border-blue-700/30 bg-blue-800/20"
+    />
+  );
+};
 
 export default function TasksPage() {
-  const [activeTab, setActiveTab] = useState("all")
-  const [viewMode, setViewMode] = useState<"my-tasks" | "organization-tasks">("my-tasks")
-  const [tasks, setTasks] = useState<Task[]>([])
-  const [meetings, setMeetings] = useState<Meeting[]>([])
-  const [selectedMeeting, setSelectedMeeting] = useState<string>("all")
-  const [searchTerm, setSearchTerm] = useState("")
-  const [showNewTaskModal, setShowNewTaskModal] = useState(false)
-  const [showEditTaskModal, setShowEditTaskModal] = useState(false)
-  const [currentTask, setCurrentTask] = useState<Task | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [organizationMembers, setOrganizationMembers] = useState([])
-  const [userFullName, setUserFullName] = useState("")
-  const [authError, setAuthError] = useState(false)
-  const [username, setUsername] = useState<string | null>(null)
-  const router = useRouter()
+  const [activeTab, setActiveTab] = useState("all");
+  const [viewMode, setViewMode] = useState<"my-tasks" | "organization-tasks">(
+    "my-tasks",
+  );
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [meetings, setMeetings] = useState<Meeting[]>([]);
+  const [selectedMeeting, setSelectedMeeting] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [showNewTaskModal, setShowNewTaskModal] = useState(false);
+  const [showEditTaskModal, setShowEditTaskModal] = useState(false);
+  const [currentTask, setCurrentTask] = useState<Task | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [organizationMembers, setOrganizationMembers] = useState([]);
+  const [userFullName, setUserFullName] = useState("");
+  const [authError, setAuthError] = useState(false);
+  const [username, setUsername] = useState<string | null>(null);
+  const router = useRouter();
 
   // Current user state
   const [currentUser, setCurrentUser] = useState({
     id: 0,
     name: "",
     role: "member" as UserRole,
-  })
+  });
 
   // Check authentication status and get username
   useEffect(() => {
     const checkAuth = async () => {
       try {
-        console.log("Verificando autenticación...")
+        console.log("Verificando autenticación...");
         // First check if we have a username in localStorage
-        const storedUsername = getUsername()
+        const storedUsername = getUsername();
 
         if (storedUsername) {
-          console.log("Username encontrado en localStorage:", storedUsername)
-          setUsername(storedUsername)
-          setAuthError(false)
-          return
+          console.log("Username encontrado en localStorage:", storedUsername);
+          setUsername(storedUsername);
+          setAuthError(false);
+          return;
         }
 
         // If no username in localStorage, try to get it from Supabase session
-        const supabase = getSupabaseClient()
-        const { data, error } = await supabase.auth.getSession()
+        const supabase = getSupabaseClient();
+        const { data, error } = await supabase.auth.getSession();
 
         if (error || !data.session) {
-          console.error("Error de autenticación:", error)
-          setAuthError(true)
-          return
+          console.error("Error de autenticación:", error);
+          setAuthError(true);
+          return;
         }
 
         // Get username from profile
@@ -225,50 +336,56 @@ export default function TasksPage() {
           .from("profiles")
           .select("username")
           .eq("id", data.session.user.id)
-          .single()
+          .single();
 
         if (profileData?.username) {
-          console.log("Username obtenido de Supabase:", profileData.username)
+          console.log("Username obtenido de Supabase:", profileData.username);
           // Store username in localStorage for future use
-          storeUsername(profileData.username)
-          setUsername(profileData.username)
-          setAuthError(false)
+          storeUsername(profileData.username);
+          setUsername(profileData.username);
+          setAuthError(false);
         } else {
-          console.error("No se encontró username en el perfil")
-          setAuthError(true)
+          console.error("No se encontró username en el perfil");
+          setAuthError(true);
         }
       } catch (error) {
-        console.error("Error verificando autenticación:", error)
-        setAuthError(true)
+        console.error("Error verificando autenticación:", error);
+        setAuthError(true);
       }
-    }
+    };
 
-    checkAuth()
-  }, [])
+    checkAuth();
+  }, []);
 
   // Función para obtener las tareas
   const fetchTasks = async (username: string) => {
     try {
-      console.log("Iniciando fetchTasks con username:", username)
-      setLoading(true)
-      setError(null)
+      console.log("Iniciando fetchTasks con username:", username);
+      setLoading(true);
+      setError(null);
 
       if (!username) {
-        console.error("No se proporcionó nombre de usuario")
-        setError("No se encontró información de usuario. Por favor, inicia sesión nuevamente.")
-        setLoading(false)
-        return
+        console.error("No se proporcionó nombre de usuario");
+        setError(
+          "No se encontró información de usuario. Por favor, inicia sesión nuevamente.",
+        );
+        setLoading(false);
+        return;
       }
 
       // Construir la URL base
-      let url = "/api/tasks"
+      let url = "/api/tasks";
 
       // Añadir el parámetro de meetingId solo si está seleccionado
-      if (selectedMeeting && selectedMeeting !== "all") {
-        url += `?meetingId=${selectedMeeting}`
+      if (selectedMeeting) {
+        url += `?meetingId=${selectedMeeting}`;
+      } else {
+        setTasks([]);
+        setLoading(false);
+        return;
       }
 
-      console.log("Fetching tasks from URL:", url)
+      console.log("Fetching tasks from URL:", url);
 
       try {
         const response = await fetch(url, {
@@ -276,124 +393,142 @@ export default function TasksPage() {
             "X-Username": username,
           },
           cache: "no-store",
-        })
+        });
 
-        console.log("Response status:", response.status)
+        console.log("Response status:", response.status);
 
         if (!response.ok) {
-          const errorText = await response.text()
-          console.error(`Error ${response.status}: ${response.statusText}`, errorText)
-          throw new Error(`Error ${response.status}: ${response.statusText || "Sin mensaje de error"}`)
+          const errorText = await response.text();
+          console.error(
+            `Error ${response.status}: ${response.statusText}`,
+            errorText,
+          );
+          throw new Error(
+            `Error ${response.status}: ${response.statusText || "Sin mensaje de error"}`,
+          );
         }
 
-        const data = await response.json()
-        console.log(`Tareas recibidas: ${data.length}`)
-        setTasks(data)
+        const data = await response.json();
+        console.log(`Tareas recibidas: ${data.length}`);
+        setTasks(data);
       } catch (err) {
-        console.error("Error en fetchTasks:", err)
-        setError(`Error al cargar las tareas: ${err.message}`)
+        console.error("Error en fetchTasks:", err);
+        setError(`Error al cargar las tareas: ${err.message}`);
       } finally {
-        setLoading(false)
+        setLoading(false);
       }
     } catch (err) {
-      console.error("Error general en fetchTasks:", err)
-      setError(`Error al cargar las tareas: ${err.message || "Error desconocido"}`)
-      setLoading(false)
+      console.error("Error general en fetchTasks:", err);
+      setError(
+        `Error al cargar las tareas: ${err.message || "Error desconocido"}`,
+      );
+      setLoading(false);
     }
-  }
+  };
 
   // Fetch conversations when username is available
   useEffect(() => {
     async function fetchData() {
       if (!username) {
-        setLoading(false)
-        return
+        setLoading(false);
+        return;
       }
 
       try {
-        setLoading(true)
-        console.log("Obteniendo datos con username:", username)
+        setLoading(true);
+        console.log("Obteniendo datos con username:", username);
 
         // Set current user
         setCurrentUser({
           id: 0,
           name: username,
           role: "admin",
-        })
+        });
 
         // Obtener información completa del usuario
         try {
-          console.log("Obteniendo información adicional del usuario")
+          console.log("Obteniendo información adicional del usuario");
           const userResponse = await fetch("/api/users/me", {
             headers: {
               "X-Username": username,
             },
             cache: "no-store",
-          })
+          });
 
           if (userResponse.ok) {
-            const userData = await userResponse.json()
-            setUserFullName(userData.full_name || username)
-            console.log("Nombre completo del usuario:", userData.full_name)
+            const userData = await userResponse.json();
+            setUserFullName(userData.full_name || username);
+            console.log("Nombre completo del usuario:", userData.full_name);
           } else {
-            console.warn("No se pudo obtener información adicional del usuario")
-            setUserFullName(username)
+            console.warn(
+              "No se pudo obtener información adicional del usuario",
+            );
+            setUserFullName(username);
           }
         } catch (err) {
-          console.error("Error obteniendo información del usuario:", err)
-          setUserFullName(username)
+          console.error("Error obteniendo información del usuario:", err);
+          setUserFullName(username);
         }
 
         // Fetch meetings
         try {
-          console.log("Obteniendo reuniones")
+          console.log("Obteniendo reuniones");
           const meetingsResponse = await fetch("/api/meetings", {
             headers: {
               "X-Username": username,
             },
             cache: "no-store",
-          })
+          });
 
           if (meetingsResponse.ok) {
-            const meetingsData = await meetingsResponse.json()
-            console.log(`Reuniones recibidas: ${meetingsData.length}`)
-            setMeetings(meetingsData)
+            const meetingsData = await meetingsResponse.json();
+            console.log(`Reuniones recibidas: ${meetingsData.length}`);
+            setMeetings(meetingsData);
           } else {
-            console.error("Error al obtener reuniones:", meetingsResponse.status)
+            console.error(
+              "Error al obtener reuniones:",
+              meetingsResponse.status,
+            );
           }
         } catch (err) {
-          console.error("Error fetching meetings:", err)
+          console.error("Error fetching meetings:", err);
           // No establecer error aquí para no bloquear la UI
         }
 
-        // Fetch tasks
-        await fetchTasks(username)
+        // Las tareas se cargan cuando se seleccione una conversación
       } catch (err) {
-        console.error("Error en fetchData:", err)
-        setError(`Error al cargar los datos: ${err.message || "Error desconocido"}`)
+        console.error("Error en fetchData:", err);
+        setError(
+          `Error al cargar los datos: ${err.message || "Error desconocido"}`,
+        );
       } finally {
-        setLoading(false)
+        setLoading(false);
       }
     }
 
-    fetchData()
-  }, [username])
+    fetchData();
+  }, [username]);
 
   // Handle meeting selection change
   useEffect(() => {
-    if (username) {
+    if (username && selectedMeeting) {
       // Usar setTimeout para asegurar que el estado se actualiza antes de ejecutar la consulta
       setTimeout(() => {
-        fetchTasks(username)
-      }, 0)
+        fetchTasks(username);
+      }, 0);
+    } else {
+      setTasks([]);
     }
-  }, [selectedMeeting, username])
+  }, [selectedMeeting, username]);
 
   // Filtrar tareas según la vista activa (Mis tareas o Tareas de la organización)
   const viewFilteredTasks =
     viewMode === "my-tasks"
       ? tasks // Mostrar todas las tareas en "Mis tareas" para depuración
-      : tasks.filter((task) => task.assignee !== userFullName && task.assignee !== "No asignado")
+      : tasks.filter(
+          (task) =>
+            task.assignee !== userFullName && task.assignee !== "No asignado",
+        );
 
   // Filtrar tareas según la pestaña activa y el término de búsqueda
   const filteredTasks = viewFilteredTasks.filter((task) => {
@@ -401,40 +536,50 @@ export default function TasksPage() {
     const matchesSearchTerm =
       searchTerm === "" ||
       task.text.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      (task.assignee && task.assignee.toLowerCase().includes(searchTerm.toLowerCase())) ||
-      (task.description && task.description.toLowerCase().includes(searchTerm.toLowerCase())) ||
-      (task.meeting_title && task.meeting_title.toLowerCase().includes(searchTerm.toLowerCase()))
+      (task.assignee &&
+        task.assignee.toLowerCase().includes(searchTerm.toLowerCase())) ||
+      (task.description &&
+        task.description.toLowerCase().includes(searchTerm.toLowerCase())) ||
+      (task.meeting_title &&
+        task.meeting_title.toLowerCase().includes(searchTerm.toLowerCase()));
 
     // Filtrar por estado (completado/pendiente)
     if (activeTab === "completed") {
-      return task.completed && matchesSearchTerm
+      return task.completed && matchesSearchTerm;
     } else if (activeTab === "pending") {
-      return !task.completed && matchesSearchTerm
+      return !task.completed && matchesSearchTerm;
     } else if (activeTab === "overdue") {
-      return !task.completed && task.dueDate && new Date(task.dueDate) < new Date() && matchesSearchTerm
+      return (
+        !task.completed &&
+        task.dueDate &&
+        new Date(task.dueDate) < new Date() &&
+        matchesSearchTerm
+      );
     }
 
     // Pestaña "todas"
-    return matchesSearchTerm
-  })
+    return matchesSearchTerm;
+  });
 
   // Añadir un log para depuración después de obtener las tareas
   useEffect(() => {
-    console.log("Tareas disponibles para mostrar:", tasks.length)
-    console.log("Tareas filtradas por vista:", viewFilteredTasks.length)
-    console.log("Tareas filtradas finales:", filteredTasks.length)
-  }, [tasks, viewFilteredTasks, filteredTasks])
+    console.log("Tareas disponibles para mostrar:", tasks.length);
+    console.log("Tareas filtradas por vista:", viewFilteredTasks.length);
+    console.log("Tareas filtradas finales:", filteredTasks.length);
+  }, [tasks, viewFilteredTasks, filteredTasks]);
 
   // Manejar el cambio de estado de una tarea
   const handleToggleComplete = async (taskId) => {
     try {
-      const taskToUpdate = tasks.find((task) => task.id === taskId)
+      const taskToUpdate = tasks.find((task) => task.id === taskId);
 
-      if (!taskToUpdate) return
+      if (!taskToUpdate) return;
 
       if (!username) {
-        setError("No se encontró información de usuario. Por favor, inicia sesión nuevamente.")
-        return
+        setError(
+          "No se encontró información de usuario. Por favor, inicia sesión nuevamente.",
+        );
+        return;
       }
 
       const response = await fetch(`/api/tasks/${taskId}`, {
@@ -447,52 +592,60 @@ export default function TasksPage() {
           completed: !taskToUpdate.completed,
           progress: !taskToUpdate.completed ? 100 : taskToUpdate.progress,
         }),
-      })
+      });
 
       if (!response.ok) {
-        const errorText = await response.text()
-        console.error("Error response:", errorText)
-        throw new Error(`Error ${response.status}: ${await response.text()}`)
+        const errorText = await response.text();
+        console.error("Error response:", errorText);
+        throw new Error(`Error ${response.status}: ${await response.text()}`);
       }
 
       // Update local state
       setTasks(
         tasks.map((task) =>
           task.id === taskId
-            ? { ...task, completed: !task.completed, progress: !taskToUpdate.completed ? 100 : task.progress }
+            ? {
+                ...task,
+                completed: !task.completed,
+                progress: !taskToUpdate.completed ? 100 : task.progress,
+              }
             : task,
         ),
-      )
+      );
 
       toast({
-        title: !taskToUpdate.completed ? "Tarea completada" : "Tarea marcada como pendiente",
+        title: !taskToUpdate.completed
+          ? "Tarea completada"
+          : "Tarea marcada como pendiente",
         description: "El estado de la tarea ha sido actualizado correctamente.",
         variant: "default",
-      })
+      });
     } catch (err) {
-      console.error("Error updating task:", err)
-      setError("Error al actualizar la tarea: " + err.message)
+      console.error("Error updating task:", err);
+      setError("Error al actualizar la tarea: " + err.message);
       toast({
         title: "Error",
         description: "No se pudo actualizar el estado de la tarea.",
         variant: "destructive",
-      })
+      });
     }
-  }
+  };
 
   // Manejar la edición de una tarea
   const handleEditTask = (task) => {
-    setCurrentTask(task)
-    setShowEditTaskModal(true)
-  }
+    setCurrentTask(task);
+    setShowEditTaskModal(true);
+  };
 
   // Manejar la eliminación de una tarea
   const handleDeleteTask = async (taskId) => {
     if (confirm("¿Estás seguro de que deseas eliminar esta tarea?")) {
       try {
         if (!username) {
-          setError("No se encontró información de usuario. Por favor, inicia sesión nuevamente.")
-          return
+          setError(
+            "No se encontró información de usuario. Por favor, inicia sesión nuevamente.",
+          );
+          return;
         }
 
         const response = await fetch(`/api/tasks/${taskId}`, {
@@ -500,40 +653,42 @@ export default function TasksPage() {
           headers: {
             "X-Username": username,
           },
-        })
+        });
 
         if (!response.ok) {
-          const errorText = await response.text()
-          console.error("Error response:", errorText)
-          throw new Error(`Error ${response.status}: ${await response.text()}`)
+          const errorText = await response.text();
+          console.error("Error response:", errorText);
+          throw new Error(`Error ${response.status}: ${await response.text()}`);
         }
 
         // Update local state
-        setTasks(tasks.filter((task) => task.id !== taskId))
+        setTasks(tasks.filter((task) => task.id !== taskId));
 
         toast({
           title: "Tarea eliminada",
           description: "La tarea ha sido eliminada correctamente.",
           variant: "default",
-        })
+        });
       } catch (err) {
-        console.error("Error deleting task:", err)
-        setError("Error al eliminar la tarea: " + err.message)
+        console.error("Error deleting task:", err);
+        setError("Error al eliminar la tarea: " + err.message);
         toast({
           title: "Error",
           description: "No se pudo eliminar la tarea.",
           variant: "destructive",
-        })
+        });
       }
     }
-  }
+  };
 
   // Manejar la creación de una tarea
   const handleCreateTask = async (newTask) => {
     try {
       if (!username) {
-        setError("No se encontró información de usuario. Por favor, inicia sesión nuevamente.")
-        return
+        setError(
+          "No se encontró información de usuario. Por favor, inicia sesión nuevamente.",
+        );
+        return;
       }
 
       // Usar directamente el string de fecha sin convertirlo a objeto Date
@@ -553,58 +708,60 @@ export default function TasksPage() {
           progress: 0,
           completed: false,
         }),
-      })
+      });
 
       if (!response.ok) {
-        const errorText = await response.text()
-        console.error("Error response:", errorText)
-        throw new Error(`Error ${response.status}: ${await response.text()}`)
+        const errorText = await response.text();
+        console.error("Error response:", errorText);
+        throw new Error(`Error ${response.status}: ${await response.text()}`);
       }
 
-      const createdTask = await response.json()
+      const createdTask = await response.json();
 
       // Update local state
-      setTasks([...tasks, createdTask])
-      setShowNewTaskModal(false)
+      setTasks([...tasks, createdTask]);
+      setShowNewTaskModal(false);
 
       toast({
         title: "Tarea creada",
         description: "La tarea ha sido creada correctamente.",
         variant: "default",
-      })
+      });
     } catch (err) {
-      console.error("Error creating task:", err)
-      setError("Error al crear la tarea: " + err.message)
+      console.error("Error creating task:", err);
+      setError("Error al crear la tarea: " + err.message);
       toast({
         title: "Error",
         description: "No se pudo crear la tarea.",
         variant: "destructive",
-      })
+      });
     }
-  }
+  };
 
   // Manejar la actualización de una tarea
   const handleUpdateTask = async (updatedTask) => {
     try {
       if (!username) {
-        setError("No se encontró información de usuario. Por favor, inicia sesión nuevamente.")
-        return false
+        setError(
+          "No se encontró información de usuario. Por favor, inicia sesión nuevamente.",
+        );
+        return false;
       }
 
-      console.log("Actualizando tarea:", updatedTask)
-      console.log("Username usado para la solicitud:", username)
+      console.log("Actualizando tarea:", updatedTask);
+      console.log("Username usado para la solicitud:", username);
 
       // Verificar que due_date tenga un formato válido
       if (!updatedTask.due_date) {
-        const errorMsg = "La fecha límite no puede estar vacía"
-        console.error(errorMsg)
-        setError(errorMsg)
+        const errorMsg = "La fecha límite no puede estar vacía";
+        console.error(errorMsg);
+        setError(errorMsg);
         toast({
           title: "Error",
           description: errorMsg,
           variant: "destructive",
-        })
-        return false
+        });
+        return false;
       }
 
       // Asegurarse de que los campos tengan los nombres correctos para la API
@@ -617,20 +774,20 @@ export default function TasksPage() {
         progress: updatedTask.progress,
         completed: updatedTask.completed,
         meeting_id: updatedTask.meeting_id,
-      }
+      };
 
-      console.log("Payload para API:", apiPayload)
+      console.log("Payload para API:", apiPayload);
 
       // Verificar si estamos en ambiente de producción
       const baseUrl =
         window.location.hostname === "localhost"
           ? "" // En desarrollo, la URL base es vacía (relativa)
-          : `${window.location.protocol}//${window.location.host}` // En producción, la URL completa
+          : `${window.location.protocol}//${window.location.host}`; // En producción, la URL completa
 
-      console.log("Base URL para la solicitud:", baseUrl)
+      console.log("Base URL para la solicitud:", baseUrl);
 
-      const url = `${baseUrl}/api/tasks/${updatedTask.id}`
-      console.log("URL completa para la solicitud:", url)
+      const url = `${baseUrl}/api/tasks/${updatedTask.id}`;
+      console.log("URL completa para la solicitud:", url);
 
       const response = await fetch(url, {
         method: "PATCH",
@@ -640,60 +797,69 @@ export default function TasksPage() {
         },
         body: JSON.stringify(apiPayload),
         credentials: "same-origin", // Importante para las cookies
-      })
+      });
 
       if (!response.ok) {
-        const errorText = await response.text()
-        console.error("Error response:", errorText)
-        throw new Error(`Error ${response.status}: ${errorText}`)
+        const errorText = await response.text();
+        console.error("Error response:", errorText);
+        throw new Error(`Error ${response.status}: ${errorText}`);
       }
 
-      const responseData = await response.json()
-      console.log("Respuesta de actualización:", responseData)
+      const responseData = await response.json();
+      console.log("Respuesta de actualización:", responseData);
 
       // Convertir el formato de la respuesta para que coincida con el formato esperado por la UI
       const formattedTask = {
         ...responseData,
         dueDate: responseData.due_date, // Asegurar que dueDate esté disponible para la UI
-      }
+      };
 
       // Update local state
-      setTasks(tasks.map((task) => (task.id === updatedTask.id ? formattedTask : task)))
-      setShowEditTaskModal(false)
-      setCurrentTask(null)
+      setTasks(
+        tasks.map((task) =>
+          task.id === updatedTask.id ? formattedTask : task,
+        ),
+      );
+      setShowEditTaskModal(false);
+      setCurrentTask(null);
 
       toast({
         title: "Tarea actualizada",
         description: "La tarea ha sido actualizada correctamente.",
         variant: "default",
-      })
+      });
 
-      return true
+      return true;
     } catch (err) {
-      console.error("Error updating task:", err)
-      setError("Error al actualizar la tarea: " + err.message)
+      console.error("Error updating task:", err);
+      setError("Error al actualizar la tarea: " + err.message);
       toast({
         title: "Error",
         description: "No se pudo actualizar la tarea: " + err.message,
         variant: "destructive",
-      })
-      return false
+      });
+      return false;
     }
-  }
+  };
 
   // Contar tareas por estado
   const taskCounts = {
     all: filteredTasks.length,
     completed: filteredTasks.filter((task) => task.completed).length,
     pending: filteredTasks.filter((task) => !task.completed).length,
-    overdue: filteredTasks.filter((task) => !task.completed && task.dueDate && new Date(task.dueDate) < new Date())
-      .length,
-  }
+    overdue: filteredTasks.filter(
+      (task) =>
+        !task.completed && task.dueDate && new Date(task.dueDate) < new Date(),
+    ).length,
+  };
+
+  const tasksWithDate = filteredTasks.filter((task) => task.dueDate);
+  const tasksWithoutDate = filteredTasks.filter((task) => !task.dueDate);
 
   // Handle login redirect
   const handleLogin = () => {
-    router.push("/login")
-  }
+    router.push("/login");
+  };
 
   // Show auth error if needed
   if (authError) {
@@ -701,20 +867,28 @@ export default function TasksPage() {
       <div className="min-h-screen bg-blue-900 flex flex-col">
         <main className="container mx-auto px-4 pb-24 pt-16 flex-1 flex flex-col items-center justify-center">
           <div className="max-w-md w-full">
-            <Alert variant="destructive" className="mb-6 bg-red-900/50 border-red-700 text-white">
+            <Alert
+              variant="destructive"
+              className="mb-6 bg-red-900/50 border-red-700 text-white"
+            >
               <AlertCircle className="h-4 w-4" />
               <AlertTitle>Error de autenticación</AlertTitle>
-              <AlertDescription>Necesitas iniciar sesión para ver tus tareas.</AlertDescription>
+              <AlertDescription>
+                Necesitas iniciar sesión para ver tus tareas.
+              </AlertDescription>
             </Alert>
 
-            <Button className="w-full bg-blue-600 hover:bg-blue-700" onClick={handleLogin}>
+            <Button
+              className="w-full bg-blue-600 hover:bg-blue-700"
+              onClick={handleLogin}
+            >
               Iniciar sesión
             </Button>
           </div>
         </main>
         <NewNavbar />
       </div>
-    )
+    );
   }
 
   if (loading) {
@@ -726,17 +900,22 @@ export default function TasksPage() {
         </div>
         <NewNavbar />
       </div>
-    )
+    );
   }
 
   return (
     <div className="min-h-screen bg-blue-900">
       <main className="container mx-auto px-4 pb-24 pt-8">
         <div className="max-w-7xl mx-auto">
-          <h1 className="text-3xl font-bold text-white mb-4 glow-text">Tareas</h1>
+          <h1 className="text-3xl font-bold text-white mb-4 glow-text">
+            Tareas
+          </h1>
 
           {error && (
-            <Alert variant="destructive" className="mb-6 bg-red-900/50 border-red-800 text-white">
+            <Alert
+              variant="destructive"
+              className="mb-6 bg-red-900/50 border-red-800 text-white"
+            >
               <AlertTitle>Error</AlertTitle>
               <AlertDescription>{error}</AlertDescription>
             </Alert>
@@ -791,240 +970,114 @@ export default function TasksPage() {
                 onChange={(e) => setSearchTerm(e.target.value)}
               />
             </div>
-
-            <div className="flex flex-col sm:flex-row gap-4">
-              {/* Selector de reunión */}
-              <div className="w-full sm:flex-1">
-                <Select value={selectedMeeting} onValueChange={setSelectedMeeting}>
-                  <SelectTrigger className="bg-blue-800/30 border-blue-700/30 text-white w-full">
-                    <SelectValue placeholder="Filtrar por reunión" />
-                  </SelectTrigger>
-                  <SelectContent className="bg-blue-800 border-blue-700 text-white">
-                    <SelectItem value="all">Todas las reuniones</SelectItem>
-                    {meetings.map((meeting) => (
-                      <SelectItem key={meeting.id} value={meeting.id.toString()}>
-                        {meeting.title}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              {/*<Button
-                className="bg-blue-600 hover:bg-blue-700 text-white w-full sm:w-auto"
-                onClick={() => setShowNewTaskModal(true)}
-              >
-                <Plus className="h-5 w-5 mr-2" />
-                Nueva tarea
-              </Button>*/}
-            </div>
           </div>
 
-          {/* Pestañas de filtrado */}
-          <Tabs defaultValue="all" value={activeTab} onValueChange={setActiveTab} className="w-full">
-            <div className="overflow-x-auto pb-2">
-              <TabsList className="grid w-full min-w-[500px] grid-cols-4 mb-8 bg-blue-800/30 gap-1 px-2 sm:px-4">
-                <TabsTrigger value="all" className="data-[state=active]:bg-blue-600">
-                  Todas ({taskCounts.all})
-                </TabsTrigger>
-                <TabsTrigger value="pending" className="data-[state=active]:bg-blue-600">
-                  Pendientes ({taskCounts.pending})
-                </TabsTrigger>
-                <TabsTrigger value="completed" className="data-[state=active]:bg-blue-600">
-                  Completadas ({taskCounts.completed})
-                </TabsTrigger>
-                <TabsTrigger value="overdue" className="data-[state=active]:bg-blue-600">
-                  Vencidas ({taskCounts.overdue})
-                </TabsTrigger>
-              </TabsList>
+
+          <div className="flex flex-col md:flex-row gap-4">
+            <div className="md:w-1/3">
+              <Card className="bg-blue-800/20 border-blue-700/30">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-white">Conversaciones</CardTitle>
+                  <CardDescription className="text-blue-200/70">
+                    Selecciona una conversación para ver sus tareas
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="max-h-[60vh] overflow-y-auto">
+                  {meetings.length > 0 ? (
+                    meetings.map((m) => (
+                      <ConversationSidebarItem
+                        key={m.id}
+                        meeting={m}
+                        isSelected={selectedMeeting === m.id.toString()}
+                        onSelect={setSelectedMeeting}
+                      />
+                    ))
+                  ) : (
+                    <div className="text-center py-8 text-blue-300">
+                      No hay conversaciones
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
             </div>
 
-            <TabsContent value="all" className="mt-0">
+            <div className="flex-1">
               <Card className="bg-blue-800/20 border-blue-700/30">
                 <CardHeader className="pb-2">
-                  <CardTitle className="text-white">
-                    {viewMode === "my-tasks" ? "Todas mis tareas" : "Todas las tareas de miembros"}
-                    {selectedMeeting !== "all" &&
-                      meetings.find((m) => m.id.toString() === selectedMeeting) &&
-                      ` - ${meetings.find((m) => m.id.toString() === selectedMeeting)?.title}`}
-                  </CardTitle>
-                  <CardDescription className="text-blue-200/70">
-                    {viewMode === "my-tasks"
-                      ? "Visualiza y gestiona todas tus tareas"
-                      : "Visualiza y gestiona todas las tareas asignadas a miembros de la organización"}
-                  </CardDescription>
+                  <CardTitle className="text-white">Tareas de la reunión</CardTitle>
+                  <Tabs
+                    defaultValue="all"
+                    value={activeTab}
+                    onValueChange={setActiveTab}
+                    className="w-full mt-4"
+                  >
+                    <div className="overflow-x-auto pb-2">
+                      <TabsList className="grid w-full min-w-[500px] grid-cols-4 bg-blue-800/30 gap-1 px-2 sm:px-4">
+                        <TabsTrigger value="all" className="data-[state=active]:bg-blue-600">
+                          Todas ({taskCounts.all})
+                        </TabsTrigger>
+                        <TabsTrigger value="pending" className="data-[state=active]:bg-blue-600">
+                          Pendientes ({taskCounts.pending})
+                        </TabsTrigger>
+                        <TabsTrigger value="completed" className="data-[state=active]:bg-blue-600">
+                          Completadas ({taskCounts.completed})
+                        </TabsTrigger>
+                        <TabsTrigger value="overdue" className="data-[state=active]:bg-blue-600">
+                          Vencidas ({taskCounts.overdue})
+                        </TabsTrigger>
+                      </TabsList>
+                    </div>
+                  </Tabs>
                 </CardHeader>
                 <CardContent>
-                  {filteredTasks.length > 0 ? (
-                    filteredTasks.map((task) => (
-                      <TaskItem
-                        key={task.id}
-                        task={task}
-                        userRole={currentUser.role}
-                        onToggleComplete={handleToggleComplete}
-                        onEdit={handleEditTask}
-                        onDelete={handleDeleteTask}
-                      />
-                    ))
-                  ) : (
-                    <div className="flex flex-col items-center justify-center py-8 text-center">
-                      <div className="rounded-full bg-blue-800/40 p-3 mb-4">
-                        <CheckSquare className="h-6 w-6 text-blue-300" />
+                  {selectedMeeting ? (
+                    <>
+                      <TasksCalendar tasks={tasksWithDate} />
+                      <div className="mt-4 space-y-4">
+                        {tasksWithDate.length > 0 ? (
+                          tasksWithDate.map((task) => (
+                            <TaskItem
+                              key={task.id}
+                              task={task}
+                              userRole={currentUser.role}
+                              onToggleComplete={handleToggleComplete}
+                              onEdit={handleEditTask}
+                              onDelete={handleDeleteTask}
+                            />
+                          ))
+                        ) : (
+                          <div className="text-center py-8 text-blue-300">
+                            No hay tareas para esta reunión
+                          </div>
+                        )}
                       </div>
-                      <h3 className="text-lg font-medium text-white mb-1">No hay tareas disponibles</h3>
-                      <p className="text-blue-300/70">
-                        {activeTab === "all"
-                          ? "No se encontraron tareas. Crea una tarea nueva para empezar."
-                          : activeTab === "pending"
-                            ? "No hay tareas pendientes en este momento."
-                            : activeTab === "completed"
-                              ? "No hay tareas completadas en este momento."
-                              : "No hay tareas vencidas en este momento."}
-                      </p>
-                      <Button className="mt-4 bg-blue-600 hover:bg-blue-700" onClick={() => setShowNewTaskModal(true)}>
-                        <Plus className="mr-2 h-4 w-4" />
-                        Nueva tarea
-                      </Button>
+                      {tasksWithoutDate.length > 0 && (
+                        <div className="mt-8">
+                          <h3 className="text-lg text-white mb-2">Tareas sin fecha</h3>
+                          <div className="space-y-4">
+                            {tasksWithoutDate.map((task) => (
+                              <TaskItem
+                                key={task.id}
+                                task={task}
+                                userRole={currentUser.role}
+                                onToggleComplete={handleToggleComplete}
+                                onEdit={handleEditTask}
+                                onDelete={handleDeleteTask}
+                              />
+                            ))}
+                          </div>
+                        </div>
+                      )}
+                    </>
+                  ) : (
+                    <div className="text-center py-8 text-blue-300">
+                      Selecciona una conversación
                     </div>
                   )}
                 </CardContent>
               </Card>
-            </TabsContent>
-
-            <TabsContent value="pending" className="mt-0">
-              <Card className="bg-blue-800/20 border-blue-700/30">
-                <CardHeader className="pb-2">
-                  <CardTitle className="text-white">
-                    {viewMode === "my-tasks" ? "Mis tareas pendientes" : "Tareas pendientes de miembros"}
-                    {selectedMeeting !== "all" &&
-                      meetings.find((m) => m.id.toString() === selectedMeeting) &&
-                      ` - ${meetings.find((m) => m.id.toString() === selectedMeeting)?.title}`}
-                  </CardTitle>
-                  <CardDescription className="text-blue-200/70">
-                    Tareas que aún necesitan ser completadas
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  {filteredTasks.length > 0 ? (
-                    filteredTasks.map((task) => (
-                      <TaskItem
-                        key={task.id}
-                        task={task}
-                        userRole={currentUser.role}
-                        onToggleComplete={handleToggleComplete}
-                        onEdit={handleEditTask}
-                        onDelete={handleDeleteTask}
-                      />
-                    ))
-                  ) : (
-                    <div className="flex flex-col items-center justify-center py-8 text-center">
-                      <div className="rounded-full bg-blue-800/40 p-3 mb-4">
-                        <CheckSquare className="h-6 w-6 text-blue-300" />
-                      </div>
-                      <h3 className="text-lg font-medium text-white mb-1">No hay tareas disponibles</h3>
-                      <p className="text-blue-300/70">
-                        {activeTab === "all"
-                          ? "No se encontraron tareas. Crea una tarea nueva para empezar."
-                          : activeTab === "pending"
-                            ? "No hay tareas pendientes en este momento."
-                            : activeTab === "completed"
-                              ? "No hay tareas completadas en este momento."
-                              : "No hay tareas vencidas en este momento."}
-                      </p>
-                      <Button className="mt-4 bg-blue-600 hover:bg-blue-700" onClick={() => setShowNewTaskModal(true)}>
-                        <Plus className="mr-2 h-4 w-4" />
-                        Nueva tarea
-                      </Button>
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
-            </TabsContent>
-
-            <TabsContent value="completed" className="mt-0">
-              <Card className="bg-blue-800/20 border-blue-700/30">
-                <CardHeader className="pb-2">
-                  <CardTitle className="text-white">
-                    {viewMode === "my-tasks" ? "Mis tareas completadas" : "Tareas completadas de miembros"}
-                    {selectedMeeting !== "all" &&
-                      meetings.find((m) => m.id.toString() === selectedMeeting) &&
-                      ` - ${meetings.find((m) => m.id.toString() === selectedMeeting)?.title}`}
-                  </CardTitle>
-                  <CardDescription className="text-blue-200/70">Tareas que ya han sido finalizadas</CardDescription>
-                </CardHeader>
-                <CardContent>
-                  {filteredTasks.length > 0 ? (
-                    filteredTasks.map((task) => (
-                      <TaskItem
-                        key={task.id}
-                        task={task}
-                        userRole={currentUser.role}
-                        onToggleComplete={handleToggleComplete}
-                        onEdit={handleEditTask}
-                        onDelete={handleDeleteTask}
-                      />
-                    ))
-                  ) : (
-                    <div className="flex flex-col items-center justify-center py-8 text-center">
-                      <div className="rounded-full bg-blue-800/40 p-3 mb-4">
-                        <CheckSquare className="h-6 w-6 text-blue-300" />
-                      </div>
-                      <h3 className="text-lg font-medium text-white mb-1">No hay tareas disponibles</h3>
-                      <p className="text-blue-300/70">
-                        {activeTab === "all"
-                          ? "No se encontraron tareas. Crea una tarea nueva para empezar."
-                          : activeTab === "pending"
-                            ? "No hay tareas pendientes en este momento."
-                            : activeTab === "completed"
-                              ? "No hay tareas completadas en este momento."
-                              : "No hay tareas vencidas en este momento."}
-                      </p>
-                      <Button className="mt-4 bg-blue-600 hover:bg-blue-700" onClick={() => setShowNewTaskModal(true)}>
-                        <Plus className="mr-2 h-4 w-4" />
-                        Nueva tarea
-                      </Button>
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
-            </TabsContent>
-
-            <TabsContent value="overdue" className="mt-0">
-              <Card className="bg-blue-800/20 border-blue-700/30">
-                <CardHeader className="pb-2">
-                  <CardTitle className="text-white">
-                    {viewMode === "my-tasks" ? "Mis tareas vencidas" : "Tareas vencidas de miembros"}
-                    {selectedMeeting !== "all" &&
-                      meetings.find((m) => m.id.toString() === selectedMeeting) &&
-                      ` - ${meetings.find((m) => m.id.toString() === selectedMeeting)?.title}`}
-                  </CardTitle>
-                  <CardDescription className="text-blue-200/70">Tareas que han pasado su fecha límite</CardDescription>
-                </CardHeader>
-                <CardContent>
-                  {filteredTasks.length > 0 ? (
-                    filteredTasks.map((task) => (
-                      <TaskItem
-                        key={task.id}
-                        task={task}
-                        userRole={currentUser.role}
-                        onToggleComplete={handleToggleComplete}
-                        onEdit={handleEditTask}
-                        onDelete={handleDeleteTask}
-                      />
-                    ))
-                  ) : (
-                    <div className="flex flex-col items-center justify-center py-8 text-center">
-                      <div className="rounded-full bg-blue-800/40 p-3 mb-4">
-                        <CheckSquare className="h-6 w-6 text-blue-300" />
-                      </div>
-                      <h3 className="text-lg font-medium text-white mb-1">No hay tareas vencidas</h3>
-                      <p className="text-blue-300/70">No tienes tareas que hayan pasado su fecha límite.</p>
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
-            </TabsContent>
-          </Tabs>
+            </div>
+          </div>
         </div>
       </main>
 
@@ -1050,8 +1103,8 @@ export default function TasksPage() {
             <EditTaskModal
               task={currentTask}
               onCancel={() => {
-                setShowEditTaskModal(false)
-                setCurrentTask(null)
+                setShowEditTaskModal(false);
+                setCurrentTask(null);
               }}
               onSave={handleUpdateTask}
               currentUser={currentUser}
@@ -1064,5 +1117,5 @@ export default function TasksPage() {
       {/* Navbar */}
       <NewNavbar />
     </div>
-  )
+  );
 }

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -29,9 +29,9 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
         nav_button_previous: "absolute left-1",
         nav_button_next: "absolute right-1",
         table: "w-full border-collapse space-y-1",
-        head_row: "flex",
+        head_row: "grid grid-cols-7",
         head_cell: "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
-        row: "flex w-full mt-2",
+        row: "grid grid-cols-7 w-full mt-2",
         cell: "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
         day: cn(
           buttonVariants({ variant: "ghost" }),


### PR DESCRIPTION
## Summary
- only load tasks when a conversation is chosen
- move status tabs inside the task panel
- show a message if no conversation is selected
- start calendar on Monday and use a grid layout for the week

## Testing
- `npm test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_68474110f17c832091a237d1b752ea75