### PR TITLE
Update task rendering in AI chat modal

### DIFF
--- a/components/ai-chat-modal.tsx
+++ b/components/ai-chat-modal.tsx
@@ -685,7 +685,10 @@ Puedo ayudarte con preguntas como:
                             )}
                           </div>
                           <div className="flex-1">
-                            <p className="text-white font-medium">{task.title}</p>
+                            <p className="text-white font-medium">{task.text}</p>
+                            {task.description && (
+                              <p className="text-blue-200/70 text-sm mt-1">{task.description}</p>
+                            )}
                             <div className="flex flex-col sm:flex-row sm:items-center text-sm text-blue-200/70 mt-1">
                               <span className="mr-3">Asignado a: {task.assignee || "No asignado"}</span>
                               <span>


### PR DESCRIPTION
## Summary
- show `task.text` instead of `task.title`
- display the task description when present

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849eecdb2848320aa374e89ac495956