### PR TITLE
Add container details endpoint

### DIFF
--- a/app/api/containers/[id]/details/route.ts
+++ b/app/api/containers/[id]/details/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server"
+import { containerService } from "@/services/containerService"
+import { getUsernameFromRequest } from "@/utils/user-helpers"
+
+export async function GET(request: Request, { params }: { params: { id: string } }) {
+  const username = await getUsernameFromRequest(request as any)
+  if (!username) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const id = Number.parseInt(params.id)
+  if (isNaN(id)) return NextResponse.json({ error: "Invalid id" }, { status: 400 })
+
+  const details = await containerService.getContainerDetails(id, username)
+  return NextResponse.json(details)
+}

--- a/services/containerService.ts
+++ b/services/containerService.ts
@@ -117,4 +117,51 @@ export const containerService = {
       return false
     }
   },
+
+  async getContainerDetails(
+    id: number,
+    username: string,
+  ): Promise<
+    Array<{
+      id: number
+      title: string
+      summary: string | null
+      keyPoints: string[]
+      tasks: any[]
+    }>
+  > {
+    try {
+      const meetings = await this.listMeetings(id, username)
+      const details = [] as Array<{
+        id: number
+        title: string
+        summary: string | null
+        keyPoints: string[]
+        tasks: any[]
+      }>
+
+      for (const meeting of meetings) {
+        const keyPoints = await query(
+          "SELECT point_text FROM key_points WHERE meeting_id = ? ORDER BY order_num",
+          [meeting.id],
+        )
+        const tasks = await query(
+          "SELECT * FROM tasks WHERE meeting_id = ? ORDER BY priority DESC, due_date ASC",
+          [meeting.id],
+        )
+        details.push({
+          id: meeting.id,
+          title: meeting.title,
+          summary: meeting.summary || null,
+          keyPoints: keyPoints.map((k: any) => k.point_text),
+          tasks,
+        })
+      }
+
+      return details
+    } catch (error) {
+      console.error("Error fetching container details:", error)
+      return []
+    }
+  },
 }


### PR DESCRIPTION
## Summary
- extend `containerService` with new `getContainerDetails` helper
- add `/api/containers/[id]/details` route to expose aggregated meeting info

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849eee8fedc832084a4c4aee15fedd3