### PR TITLE
Enable container summaries in AI chat

### DIFF
--- a/app/api/containers/[id]/details/route.ts
+++ b/app/api/containers/[id]/details/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server"
+import { containerService } from "@/services/containerService"
+import { getUsernameFromRequest } from "@/utils/user-helpers"
+
+export async function GET(request: Request, { params }: { params: { id: string } }) {
+  const username = await getUsernameFromRequest(request as any)
+  if (!username) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  const id = Number.parseInt(params.id)
+  if (isNaN(id)) return NextResponse.json({ error: "Invalid id" }, { status: 400 })
+  try {
+    const details = await containerService.getContainerDetails(id, username)
+    if (!details) return NextResponse.json({ error: "Not found" }, { status: 404 })
+    return NextResponse.json(details)
+  } catch (error) {
+    console.error("Error fetching container details:", error)
+    return NextResponse.json({ error: "Error fetching container details" }, { status: 500 })
+  }
+}

--- a/services/containerService.ts
+++ b/services/containerService.ts
@@ -117,4 +117,46 @@ export const containerService = {
       return false
     }
   },
+
+  async getContainerDetails(id: number, username: string): Promise<any | null> {
+    try {
+      const container = await this.getContainerById(id, username)
+      if (!container) return null
+
+      const summaries = await query(
+        `SELECT m.id as meeting_id, m.title, m.summary
+         FROM container_meetings cm
+         JOIN meetings m ON cm.meeting_id = m.id
+         WHERE cm.container_id = ? AND m.username = ?
+         ORDER BY m.date DESC`,
+        [id, username],
+      )
+
+      const keyPoints = await query(
+        `SELECT kp.id, kp.meeting_id, kp.point_text, m.title as meeting_title
+         FROM key_points kp
+         JOIN meetings m ON kp.meeting_id = m.id
+         JOIN container_meetings cm ON cm.meeting_id = kp.meeting_id
+         WHERE cm.container_id = ? AND m.username = ?
+         ORDER BY kp.order_num`,
+        [id, username],
+      )
+
+      const tasks = await query(
+        `SELECT t.id, t.text as title, t.description, t.assignee, t.due_date, t.completed, t.priority, t.progress,
+                t.meeting_id, m.title as meeting_title
+         FROM tasks t
+         JOIN meetings m ON t.meeting_id = m.id
+         JOIN container_meetings cm ON cm.meeting_id = t.meeting_id
+         WHERE cm.container_id = ? AND m.username = ?
+         ORDER BY t.due_date ASC, t.priority DESC`,
+        [id, username],
+      )
+
+      return { summaries, keyPoints, tasks }
+    } catch (error) {
+      console.error("Error fetching container details:", error)
+      return null
+    }
+  },
 }


### PR DESCRIPTION
## Summary
- implement aggregated container details in `containerService`
- expose new endpoint `/api/containers/[id]/details`
- enhance `AIChatModal` to load container data and display aggregated
  summaries, key points and tasks
- reset container state when meeting changes

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849eef0efe08320aadc7b75346d78da