### PR TITLE
Fix conversation key handling

### DIFF
--- a/components/ai-chat-modal.tsx
+++ b/components/ai-chat-modal.tsx
@@ -50,6 +50,13 @@ export const AIChatModal = ({ meeting, container = null, onClose }) => {
   const chatContainerRef = useRef(null)
   const { isMobile } = useDevice()
 
+  const conversationKey =
+    selectedMeeting?.id !== undefined
+      ? String(selectedMeeting.id)
+      : selectedContainerId !== null
+      ? `container-${selectedContainerId}`
+      : null
+
 
   useEffect(() => {
     setSelectedContainer(container)
@@ -61,15 +68,17 @@ export const AIChatModal = ({ meeting, container = null, onClose }) => {
     const username = getUsername()
     if (!username) {
       setIsAuthenticated(false)
-      // Inicializar con mensaje de error de autenticación
-      setConversations({
-        [conversationKey as string]: [
-          {
-            role: "assistant",
-            content: "⚠️ Error de autenticación: No hay sesión activa. Por favor, inicia sesión de nuevo.",
-          },
-        ],
-      })
+      if (conversationKey) {
+        // Inicializar con mensaje de error de autenticación
+        setConversations({
+          [conversationKey]: [
+            {
+              role: "assistant",
+              content: "⚠️ Error de autenticación: No hay sesión activa. Por favor, inicia sesión de nuevo.",
+            },
+          ],
+        })
+      }
     } else {
       // Inicializar con mensaje de bienvenida solo si está autenticado
       const welcomeMessage = {
@@ -93,9 +102,11 @@ Puedo ayudarte con preguntas como:
 ¿En qué puedo ayudarte hoy?`,
       }
 
-      setConversations({
-        [conversationKey as string]: [welcomeMessage],
-      })
+      if (conversationKey) {
+        setConversations({
+          [conversationKey]: [welcomeMessage],
+        })
+      }
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- compute `conversationKey` from selected meeting or container
- avoid storing conversations when the key is null

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f3f6d6088320acf9a488cc078c0f