### PR TITLE
Improve container management UX

### DIFF
--- a/app/ai-assistant/page.tsx
+++ b/app/ai-assistant/page.tsx
@@ -204,7 +204,6 @@ export default function AIAssistantPage() {
             </div>
           ),
         })
-        window.location.reload()
       }
     } catch (err) {
       console.error("Error creando contenedor", err)

--- a/components/add-to-container-modal.tsx
+++ b/components/add-to-container-modal.tsx
@@ -1,0 +1,111 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Check, X } from "lucide-react"
+import { addUsernameToHeaders } from "@/utils/user-helpers"
+
+interface Meeting { id: number; title: string }
+
+interface AddToContainerModalProps {
+  containerId: number
+  onClose: () => void
+  onAdded: () => void
+}
+
+export function AddToContainerModal({ containerId, onClose, onAdded }: AddToContainerModalProps) {
+  const [meetings, setMeetings] = useState<Meeting[]>([])
+  const [selected, setSelected] = useState<Set<number>>(new Set())
+  const [adding, setAdding] = useState(false)
+  const [showSuccess, setShowSuccess] = useState(false)
+
+  useEffect(() => {
+    const fetchMeetings = async () => {
+      try {
+        const res = await fetch("/api/meetings", { headers: addUsernameToHeaders() })
+        if (res.ok) {
+          const data = await res.json()
+          setMeetings(data)
+        }
+      } catch (err) {
+        console.error("Error loading meetings", err)
+      }
+    }
+    fetchMeetings()
+  }, [])
+
+  const toggleSelect = (id: number) => {
+    setSelected((prev) => {
+      const newSet = new Set(prev)
+      if (newSet.has(id)) {
+        newSet.delete(id)
+      } else {
+        newSet.add(id)
+      }
+      return newSet
+    })
+  }
+
+  const handleAdd = async () => {
+    if (selected.size === 0) return
+    setAdding(true)
+    try {
+      for (const id of Array.from(selected)) {
+        await fetch(`/api/containers/${containerId}/meetings`, {
+          method: "POST",
+          headers: addUsernameToHeaders({ "Content-Type": "application/json" }),
+          body: JSON.stringify({ meetingId: id }),
+        })
+      }
+      setShowSuccess(true)
+      onAdded()
+    } catch (err) {
+      console.error("Error adding meeting", err)
+    } finally {
+      setAdding(false)
+    }
+  }
+
+  return (
+    <>
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+        <div className="bg-blue-800/95 border border-blue-700/30 rounded-lg p-6 w-full max-w-sm">
+          <div className="flex justify-between items-center mb-4">
+            <h2 className="text-lg font-semibold text-white">Añadir reunión</h2>
+            <Button variant="ghost" size="icon" className="text-blue-200 hover:text-white" onClick={onClose}>
+              <X className="h-5 w-5" />
+            </Button>
+          </div>
+          <div className="space-y-2 max-h-[50vh] overflow-y-auto">
+            {meetings.map((m) => (
+              <button
+                key={m.id}
+                onClick={() => toggleSelect(m.id)}
+                className={`w-full flex items-center justify-between text-left px-3 py-2 rounded ${selected.has(m.id) ? "bg-blue-600" : "bg-blue-700/40 hover:bg-blue-700/60"}`}
+              >
+                <span>{m.title}</span>
+                {selected.has(m.id) && <Check className="h-4 w-4" />}
+              </button>
+            ))}
+          </div>
+          <div className="flex justify-end gap-2 mt-4">
+            <Button variant="outline" onClick={onClose} disabled={adding}>Cancelar</Button>
+            <Button className="bg-blue-600 hover:bg-blue-700" onClick={handleAdd} disabled={adding}>
+              {adding ? "Añadiendo..." : "Añadir"}
+            </Button>
+          </div>
+        </div>
+      </div>
+      {showSuccess && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+          <div className="bg-blue-800/95 border border-blue-700/30 rounded-lg p-6 w-full max-w-sm text-center">
+            <p className="text-white mb-4">Reuniones añadidas correctamente</p>
+            <Button className="bg-blue-600 hover:bg-blue-700" onClick={() => { setShowSuccess(false); onClose(); }}>
+              Aceptar
+            </Button>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/components/ai-chat-modal.tsx
+++ b/components/ai-chat-modal.tsx
@@ -50,9 +50,21 @@ export const AIChatModal = ({ meeting, container = null, onClose }) => {
   const chatContainerRef = useRef(null)
   const { isMobile } = useDevice()
 
+  const conversationKey =
+    selectedMeeting?.id !== undefined
+      ? String(selectedMeeting.id)
+      : selectedContainer?.id !== undefined
+      ? `container-${selectedContainer.id}`
+      : selectedContainerId !== null
+      ? `container-${selectedContainerId}`
+      : null
+
 
   useEffect(() => {
     setSelectedContainer(container)
+    if (container?.id !== undefined) {
+      setSelectedContainerId(container.id)
+    }
   }, [container?.id])
 
 
@@ -61,15 +73,17 @@ export const AIChatModal = ({ meeting, container = null, onClose }) => {
     const username = getUsername()
     if (!username) {
       setIsAuthenticated(false)
-      // Inicializar con mensaje de error de autenticación
-      setConversations({
-        [conversationKey as string]: [
-          {
-            role: "assistant",
-            content: "⚠️ Error de autenticación: No hay sesión activa. Por favor, inicia sesión de nuevo.",
-          },
-        ],
-      })
+      if (conversationKey) {
+        // Inicializar con mensaje de error de autenticación
+        setConversations({
+          [conversationKey]: [
+            {
+              role: "assistant",
+              content: "⚠️ Error de autenticación: No hay sesión activa. Por favor, inicia sesión de nuevo.",
+            },
+          ],
+        })
+      }
     } else {
       // Inicializar con mensaje de bienvenida solo si está autenticado
       const welcomeMessage = {
@@ -93,9 +107,11 @@ Puedo ayudarte con preguntas como:
 ¿En qué puedo ayudarte hoy?`,
       }
 
-      setConversations({
-        [conversationKey as string]: [welcomeMessage],
-      })
+      if (conversationKey) {
+        setConversations({
+          [conversationKey]: [welcomeMessage],
+        })
+      }
     }
   }, [])
 
@@ -192,6 +208,7 @@ Puedo ayudarte con preguntas como:
 
   const handleSelectContainer = (container) => {
     setSelectedContainerId(container.id)
+    setSelectedContainer(container)
     setSelectedMeeting(null)
     setMeetingDetails(null)
     setIsLoadingDetails(false)
@@ -344,11 +361,11 @@ Puedo ayudarte con preguntas como:
       const response = await fetch("/api/ai-chat", {
         method: "POST",
         headers,
-        body: JSON.stringify({
-          messages: recentMessages.map((msg) => ({ role: msg.role, content: msg.content })),
+          body: JSON.stringify({
+            messages: recentMessages.map((msg) => ({ role: msg.role, content: msg.content })),
 
-          meetingId: selectedMeeting.id,
-          containerId: selectedContainer?.id || null,
+            meetingId: selectedMeeting?.id || null,
+            containerId: selectedContainer?.id || null,
 
           searchWeb: isSearchingWeb,
         }),
@@ -425,7 +442,9 @@ Puedo ayudarte con preguntas como:
           {/* Título y fecha en móvil - centrados */}
           <div className="flex flex-col items-center sm:items-start p-3 sm:hidden">
             <h2 className="text-lg font-semibold text-white">
-              {selectedMeeting ? selectedMeeting.title : `Contenedor ${selectedContainerId}`}
+              {selectedMeeting
+                ? selectedMeeting.title
+                : selectedContainer?.name || `Contenedor ${selectedContainerId}`}
             </h2>
             {selectedMeeting && (
               <div className="text-blue-200/70 text-sm mt-1">
@@ -440,7 +459,9 @@ Puedo ayudarte con preguntas como:
           <div className="hidden sm:flex flex-row items-center justify-between p-4">
             <div className="flex flex-col">
               <h2 className="text-xl font-semibold text-white">
-                {selectedMeeting ? selectedMeeting.title : `Contenedor ${selectedContainerId}`}
+                {selectedMeeting
+                  ? selectedMeeting.title
+                  : selectedContainer?.name || `Contenedor ${selectedContainerId}`}
               </h2>
               {selectedMeeting && (
                 <div className="text-blue-200/70 text-sm mt-1">

--- a/components/container-panel.tsx
+++ b/components/container-panel.tsx
@@ -11,7 +11,9 @@ import {
 } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
 import { addUsernameToHeaders } from "@/utils/user-helpers";
-import { ChevronDown, Plus } from "lucide-react";
+import { ChevronDown, Plus, Trash2 } from "lucide-react";
+import { AddToContainerModal } from "./add-to-container-modal";
+import { DeleteContainerModal } from "./delete-container-modal";
 
 
 interface Container {
@@ -32,22 +34,26 @@ interface ContainerPanelProps {
 export function ContainerPanel({ onMeetingSelect }: ContainerPanelProps) {
   const [containers, setContainers] = useState<Container[]>([]);
   const [expanded, setExpanded] = useState<number | null>(null);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [showAddModal, setShowAddModal] = useState<Container | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Container | null>(null);
 
+
+  const fetchContainers = async () => {
+    try {
+      const res = await fetch("/api/containers", {
+        headers: addUsernameToHeaders(),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setContainers(data);
+      }
+    } catch (err) {
+      console.error("Error loading containers", err);
+    }
+  };
 
   useEffect(() => {
-    const fetchContainers = async () => {
-      try {
-        const res = await fetch("/api/containers", {
-          headers: addUsernameToHeaders(),
-        });
-        if (res.ok) {
-          const data = await res.json();
-          setContainers(data);
-        }
-      } catch (err) {
-        console.error("Error loading containers", err);
-      }
-    };
     fetchContainers();
   }, []);
 
@@ -74,6 +80,22 @@ export function ContainerPanel({ onMeetingSelect }: ContainerPanelProps) {
     }
   };
 
+  const confirmDelete = async (id: number) => {
+    try {
+      const res = await fetch(`/api/containers/${id}`, {
+        method: "DELETE",
+        headers: addUsernameToHeaders(),
+      })
+      if (res.ok) {
+        setContainers((prev) => prev.filter((c) => c.id !== id))
+        setExpanded((prev) => (prev === id ? null : prev))
+        setDeleteTarget(null)
+      }
+    } catch (err) {
+      console.error("Error deleting container", err)
+    }
+  }
+
   return (
     <Sheet>
       <SheetTrigger asChild>
@@ -91,18 +113,47 @@ export function ContainerPanel({ onMeetingSelect }: ContainerPanelProps) {
         <SheetHeader className="p-4 border-b border-blue-700/30">
           <SheetTitle>Contenedores</SheetTitle>
         </SheetHeader>
+        <div className="p-4 border-b border-blue-700/30">
+          <input
+            type="text"
+            placeholder="Buscar contenedor"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className="w-full bg-blue-700/40 border border-blue-600/50 text-white rounded-lg p-2.5"
+          />
+        </div>
         <div className="p-4 space-y-2 overflow-y-auto h-full">
-          {containers.map((c) => (
+          {containers
+            .filter((c) =>
+              c.name.toLowerCase().includes(searchTerm.toLowerCase()),
+            )
+            .map((c) => (
             <div key={c.id} className="border border-blue-700/50 rounded-lg">
-              <button
-                onClick={() => toggleExpand(c.id)}
-                className="w-full flex justify-between items-center p-3 bg-blue-800/50 hover:bg-blue-800"
-              >
-                <span>{c.name}</span>
-                <ChevronDown
-                  className={`h-4 w-4 transition-transform ${expanded === c.id ? "rotate-180" : ""}`}
-                />
-              </button>
+              <div className="flex items-center justify-between p-3 bg-blue-800/50">
+                <button
+                  onClick={() => toggleExpand(c.id)}
+                  className="flex-1 text-left flex items-center justify-between"
+                >
+                  <span>{c.name}</span>
+                  <ChevronDown
+                    className={`h-4 w-4 transition-transform ${expanded === c.id ? "rotate-180" : ""}`}
+                  />
+                </button>
+                <div className="flex items-center gap-2 ml-2">
+                  <button
+                    onClick={() => setShowAddModal(c)}
+                    className="text-blue-200 hover:text-white"
+                  >
+                    <Plus className="h-4 w-4" />
+                  </button>
+                  <button
+                    onClick={() => setDeleteTarget(c)}
+                    className="text-red-300 hover:text-red-500"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
+              </div>
               {expanded === c.id && meetings[c.id] && (
                 <div className="bg-blue-800/40 p-2 space-y-1">
                   {meetings[c.id].map((m) => (
@@ -123,6 +174,20 @@ export function ContainerPanel({ onMeetingSelect }: ContainerPanelProps) {
           )}
         </div>
       </SheetContent>
+      {showAddModal && (
+        <AddToContainerModal
+          containerId={showAddModal.id}
+          onClose={() => setShowAddModal(null)}
+          onAdded={() => fetchContainers()}
+        />
+      )}
+      {deleteTarget && (
+        <DeleteContainerModal
+          container={deleteTarget}
+          onCancel={() => setDeleteTarget(null)}
+          onConfirm={(id) => confirmDelete(id)}
+        />
+      )}
     </Sheet>
   );
 }

--- a/components/delete-container-modal.tsx
+++ b/components/delete-container-modal.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { Trash2 } from "lucide-react"
+
+interface DeleteContainerModalProps {
+  container: { id: number; name: string }
+  onConfirm: (id: number) => void
+  onCancel: () => void
+}
+
+export function DeleteContainerModal({ container, onConfirm, onCancel }: DeleteContainerModalProps) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="bg-blue-800/95 border border-blue-700/30 rounded-lg p-6 w-full max-w-sm">
+        <div className="flex items-center justify-center mb-4">
+          <div className="h-12 w-12 rounded-full bg-red-500/20 flex items-center justify-center">
+            <Trash2 className="h-6 w-6 text-red-400" />
+          </div>
+        </div>
+        <h2 className="text-xl font-bold text-white text-center mb-2">Eliminar Contenedor</h2>
+        <p className="text-blue-200 text-center mb-6">
+          ¿Estás seguro de que deseas eliminar "{container.name}"? Esta acción no se puede deshacer.
+        </p>
+        <div className="flex gap-3">
+          <Button variant="outline" className="flex-1" onClick={onCancel}>
+            Cancelar
+          </Button>
+          <Button variant="destructive" className="flex-1 bg-red-600 hover:bg-red-700" onClick={() => onConfirm(container.id)}>
+            Eliminar
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- support selecting multiple meetings when adding to a container
- display confirmation modal after meetings are added
- add modal dialog for deleting containers
- refresh container list on deletion and remove page reload on container creation

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f3f6d6088320acf9a488cc078c0f