### PR TITLE
Fix duplicate variable causing build error

### DIFF
--- a/components/container-panel.tsx
+++ b/components/container-panel.tsx
@@ -36,9 +36,6 @@ export function ContainerPanel({ onMeetingSelect }: ContainerPanelProps) {
   const [showAddModal, setShowAddModal] = useState<Container | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Container | null>(null);
 
-
-  const [deleteTarget, setDeleteTarget] = useState<Container | null>(null);
-
   const fetchContainers = async () => {
     try {
       const res = await fetch("/api/containers", {


### PR DESCRIPTION
## Summary
- fix duplicate deleteTarget `useState` declaration

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a0498c4d88320abd32c33a93f0a71