### PR TITLE
Implement Juntify changes admin module

### DIFF
--- a/app/admin/juntify-changes/page.tsx
+++ b/app/admin/juntify-changes/page.tsx
@@ -1,0 +1,179 @@
+"use client"
+
+import { useEffect, useState, FormEvent } from "react"
+import { NewNavbar } from "@/components/new-navbar"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Edit, Trash2 } from "lucide-react"
+
+interface Change {
+  id: number
+  version: string
+  description: string
+}
+
+export default function JuntifyChangesPage() {
+  const [changes, setChanges] = useState<Change[]>([])
+  const [version, setVersion] = useState("")
+  const [description, setDescription] = useState("")
+  const [error, setError] = useState("")
+  const [editingId, setEditingId] = useState<number | null>(null)
+
+  const fetchChanges = async () => {
+    const res = await fetch("/api/juntify-changes")
+    if (res.ok) {
+      const data = await res.json()
+      setChanges(data)
+    }
+  }
+
+  useEffect(() => {
+    fetchChanges()
+  }, [])
+
+  const handleCreate = async (e: FormEvent) => {
+    e.preventDefault()
+    if (!version.trim() || !description.trim()) {
+      setError("Versión y descripción son requeridas")
+      return
+    }
+    const res = await fetch("/api/juntify-changes", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: version.trim(), description })
+    })
+    if (res.ok) {
+      setVersion("")
+      setDescription("")
+      setError("")
+      fetchChanges()
+    } else {
+      const data = await res.json()
+      setError(data.error || "Error al guardar")
+    }
+  }
+
+  const handleUpdate = async (e: FormEvent) => {
+    e.preventDefault()
+    if (editingId === null) return
+    if (!version.trim() || !description.trim()) {
+      setError("Versión y descripción son requeridas")
+      return
+    }
+    const res = await fetch(`/api/juntify-changes/${editingId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: version.trim(), description })
+    })
+    if (res.ok) {
+      setVersion("")
+      setDescription("")
+      setEditingId(null)
+      setError("")
+      fetchChanges()
+    } else {
+      const data = await res.json()
+      setError(data.error || "Error al actualizar")
+    }
+  }
+
+  const handleDelete = async (id: number) => {
+    if (!confirm("¿Eliminar cambio?")) return
+    const res = await fetch(`/api/juntify-changes/${id}`, { method: "DELETE" })
+    if (res.ok) {
+      fetchChanges()
+    }
+  }
+
+  const startEdit = (change: Change) => {
+    setEditingId(change.id)
+    setVersion(change.version)
+    setDescription(change.description)
+  }
+
+  const cancelEdit = () => {
+    setEditingId(null)
+    setVersion("")
+    setDescription("")
+    setError("")
+  }
+
+  return (
+    <div className="min-h-screen bg-blue-900">
+      <main className="container mx-auto px-4 pb-24 pt-8">
+        <div className="max-w-3xl mx-auto space-y-6">
+          <h1 className="text-3xl font-bold text-white mb-4 glow-text">Cambios de Juntify</h1>
+          <Card className="bg-blue-800/30 border-blue-700/30 text-white">
+            <CardHeader>
+              <CardTitle>{editingId ? "Editar Cambio" : "Nuevo Cambio"}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {error && (
+                <Alert variant="destructive" className="mb-4 bg-red-900/40 border-red-800 text-white">
+                  <AlertTitle>Error</AlertTitle>
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              )}
+              <form onSubmit={editingId ? handleUpdate : handleCreate} className="space-y-4">
+                <Input
+                  placeholder="Versión"
+                  value={version}
+                  onChange={(e) => setVersion(e.target.value)}
+                  className="bg-blue-900/40 border-blue-700/30 text-white"
+                />
+                <Textarea
+                  placeholder="Descripción"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  className="bg-blue-900/40 border-blue-700/30 text-white"
+                />
+                <div className="flex gap-2">
+                  <Button type="submit" className="bg-blue-600 hover:bg-blue-700">
+                    {editingId ? "Actualizar" : "Guardar"}
+                  </Button>
+                  {editingId && (
+                    <Button type="button" variant="ghost" onClick={cancelEdit}>
+                      Cancelar
+                    </Button>
+                  )}
+                </div>
+              </form>
+            </CardContent>
+          </Card>
+
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm text-blue-200">
+              <thead>
+                <tr className="text-blue-300">
+                  <th className="pb-2">Versión</th>
+                  <th className="pb-2">Cambios</th>
+                  <th className="pb-2">Acciones</th>
+                </tr>
+              </thead>
+              <tbody>
+                {changes.map((chg) => (
+                  <tr key={chg.id} className="border-t border-blue-700/30">
+                    <td className="py-2 align-top pr-2">{chg.version}</td>
+                    <td className="py-2 align-top pr-2 whitespace-pre-wrap">{chg.description}</td>
+                    <td className="py-2 space-x-2">
+                      <Button variant="ghost" size="icon" onClick={() => startEdit(chg)} aria-label="Editar">
+                        <Edit className="h-4 w-4" />
+                      </Button>
+                      <Button variant="ghost" size="icon" onClick={() => handleDelete(chg.id)} aria-label="Eliminar">
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </main>
+      <NewNavbar />
+    </div>
+  )
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -7,6 +7,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import Link from "next/link"
 import {
   MessageSquare,
   History,
@@ -18,12 +19,17 @@ import {
 
 export default function AdminPage() {
   const options = [
-    { title: "Feedbacks", icon: MessageSquare },
-    { title: "Cambios de Juntify", icon: History },
-    { title: "Administración de usuarios", icon: UserCog },
-    { title: "Administración de analizadores", icon: Settings2 },
-    { title: "Políticas y privacidad", icon: FileText },
-    { title: "Estadísticas", icon: BarChart },
+    { title: "Feedbacks", icon: MessageSquare, available: false },
+    {
+      title: "Cambios de Juntify",
+      icon: History,
+      available: true,
+      href: "/admin/juntify-changes",
+    },
+    { title: "Administración de usuarios", icon: UserCog, available: false },
+    { title: "Administración de analizadores", icon: Settings2, available: false },
+    { title: "Políticas y privacidad", icon: FileText, available: false },
+    { title: "Estadísticas", icon: BarChart, available: false },
   ]
 
   return (
@@ -32,17 +38,26 @@ export default function AdminPage() {
         <div className="max-w-7xl mx-auto">
           <h1 className="text-3xl font-bold text-white mb-8 glow-text">Panel de Administración</h1>
           <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
-            {options.map(({ title, icon: Icon }) => (
-              <Card key={title} className="bg-blue-800/30 border-blue-700/30 text-white hover:border-blue-500/50">
-                <CardHeader className="flex flex-row items-center space-x-3">
-                  <Icon className="h-5 w-5 text-blue-300" />
-                  <CardTitle className="text-lg">{title}</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-blue-300">Próximamente</p>
-                </CardContent>
-              </Card>
-            ))}
+            {options.map(({ title, icon: Icon, available, href }) => {
+              const card = (
+                <Card className="bg-blue-800/30 border-blue-700/30 text-white hover:border-blue-500/50">
+                  <CardHeader className="flex flex-row items-center space-x-3">
+                    <Icon className="h-5 w-5 text-blue-300" />
+                    <CardTitle className="text-lg">{title}</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-blue-300">{available ? "Administrar" : "Próximamente"}</p>
+                  </CardContent>
+                </Card>
+              )
+              return available && href ? (
+                <Link href={href} key={title} className="block">
+                  {card}
+                </Link>
+              ) : (
+                <div key={title}>{card}</div>
+              )
+            })}
           </div>
         </div>
       </main>

--- a/app/api/juntify-changes/[id]/route.ts
+++ b/app/api/juntify-changes/[id]/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server"
+import { juntifyChangesService } from "@/services/juntifyChangesService"
+
+export async function PATCH(request: Request, { params }: { params: { id: string } }) {
+  try {
+    const id = Number.parseInt(params.id)
+    if (isNaN(id)) {
+      return NextResponse.json({ error: "Invalid id" }, { status: 400 })
+    }
+    const { version, description } = await request.json()
+    if (!version || !description) {
+      return NextResponse.json({ error: "Version and description required" }, { status: 400 })
+    }
+    const change = await juntifyChangesService.updateChange(id, version, description)
+    if (!change) {
+      return NextResponse.json({ error: "Change not found" }, { status: 404 })
+    }
+    return NextResponse.json(change)
+  } catch (error) {
+    console.error("Error updating juntify change:", error)
+    return NextResponse.json({ error: "Error updating juntify change" }, { status: 500 })
+  }
+}
+
+export async function DELETE(request: Request, { params }: { params: { id: string } }) {
+  try {
+    const id = Number.parseInt(params.id)
+    if (isNaN(id)) {
+      return NextResponse.json({ error: "Invalid id" }, { status: 400 })
+    }
+    const success = await juntifyChangesService.deleteChange(id)
+    if (!success) {
+      return NextResponse.json({ error: "Change not found" }, { status: 404 })
+    }
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error("Error deleting juntify change:", error)
+    return NextResponse.json({ error: "Error deleting juntify change" }, { status: 500 })
+  }
+}

--- a/app/api/juntify-changes/route.ts
+++ b/app/api/juntify-changes/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server"
+import { juntifyChangesService } from "@/services/juntifyChangesService"
+
+export async function GET() {
+  try {
+    const changes = await juntifyChangesService.getAll()
+    return NextResponse.json(changes)
+  } catch (error) {
+    console.error("Error fetching juntify changes:", error)
+    return NextResponse.json({ error: "Error fetching juntify changes" }, { status: 500 })
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const { version, description } = await request.json()
+    if (!version || !description) {
+      return NextResponse.json({ error: "Version and description required" }, { status: 400 })
+    }
+    const change = await juntifyChangesService.createChange(version, description)
+    return NextResponse.json(change)
+  } catch (error) {
+    console.error("Error creating juntify change:", error)
+    return NextResponse.json({ error: "Error creating juntify change" }, { status: 500 })
+  }
+}

--- a/services/juntifyChangesService.ts
+++ b/services/juntifyChangesService.ts
@@ -1,0 +1,61 @@
+import { query, queryOne } from "@/utils/mysql"
+
+export interface JuntifyChange {
+  id: number
+  version: string
+  description: string
+  change_date: string
+  change_time: string
+  created_at: Date
+  updated_at: Date
+}
+
+export const juntifyChangesService = {
+  async getAll(): Promise<JuntifyChange[]> {
+    try {
+      return await query<JuntifyChange>(
+        "SELECT * FROM juntify_changes ORDER BY change_date DESC, change_time DESC"
+      )
+    } catch (error) {
+      console.error("Error fetching juntify changes:", error)
+      return []
+    }
+  },
+
+  async createChange(version: string, description: string): Promise<JuntifyChange | null> {
+    try {
+      const result = await query(
+        "INSERT INTO juntify_changes (version, description, change_date, change_time) VALUES (?, ?, CURDATE(), CURTIME())",
+        [version, description]
+      )
+      const insertId = result.insertId
+      return await queryOne<JuntifyChange>("SELECT * FROM juntify_changes WHERE id = ?", [insertId])
+    } catch (error) {
+      console.error("Error creating juntify change:", error)
+      return null
+    }
+  },
+
+  async updateChange(id: number, version: string, description: string): Promise<JuntifyChange | null> {
+    try {
+      await query(
+        "UPDATE juntify_changes SET version = ?, description = ? WHERE id = ?",
+        [version, description, id]
+      )
+      return await queryOne<JuntifyChange>("SELECT * FROM juntify_changes WHERE id = ?", [id])
+    } catch (error) {
+      console.error("Error updating juntify change:", error)
+      return null
+    }
+  },
+
+  async deleteChange(id: number): Promise<boolean> {
+    try {
+      const result = await query("DELETE FROM juntify_changes WHERE id = ?", [id])
+      return result.affectedRows > 0
+    } catch (error) {
+      console.error("Error deleting juntify change:", error)
+      return false
+    }
+  },
+}


### PR DESCRIPTION
## Summary
- add service for managing `juntify_changes` records
- create API endpoints for CRUD operations
- implement admin page to view and edit Juntify change log
- link new page from admin panel

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a386393548320ba69f85032fb6feb