### PR TITLE
Fix fetchChanges call in admin page

### DIFF
--- a/app/admin/juntify-changes/page.tsx
+++ b/app/admin/juntify-changes/page.tsx
@@ -56,10 +56,12 @@ function formatDescription(text: string) {
   const [editingId, setEditingId] = useState<number | null>(null);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleteId, setDeleteId] = useState<number | null>(null);
-    const res = await fetch("/api/juntify-changes");
+  useEffect(() => {
+    async function fetchChanges() {
+      const res = await fetch("/api/juntify-changes");
       const data = await res.json();
       setChanges(data);
-  };
+    }
     fetchChanges();
   }, []);
     e.preventDefault();


### PR DESCRIPTION
## Summary
- wrap `fetchChanges` call in `useEffect` and remove stray await

## Testing
- `npx tsc --noEmit app/admin/juntify-changes/page.tsx` *(fails: TS errors unrelated to await)*

------
https://chatgpt.com/codex/tasks/task_e_684a42880358832080b5b172839d1149