### PR TITLE
Fix fetchChanges call in admin page

### DIFF
--- a/app/admin/feedbacks/page.tsx
+++ b/app/admin/feedbacks/page.tsx
@@ -1,0 +1,119 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { NewNavbar } from "@/components/new-navbar"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Trash2 } from "lucide-react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+interface Feedback {
+  id: number
+  username: string | null
+  message: string
+  created_at: string
+}
+
+export default function FeedbacksPage() {
+  const [feedbacks, setFeedbacks] = useState<Feedback[]>([])
+  const [showDelete, setShowDelete] = useState(false)
+  const [deleteId, setDeleteId] = useState<number | null>(null)
+
+  const refresh = async () => {
+    const res = await fetch("/api/feedback")
+    if (res.ok) {
+      const data = await res.json()
+      setFeedbacks(data)
+    }
+  }
+
+  useEffect(() => {
+    async function fetchFeedbacks() {
+      await refresh()
+    }
+    fetchFeedbacks()
+  }, [])
+
+  const confirmDelete = (id: number) => {
+    setDeleteId(id)
+    setShowDelete(true)
+  }
+
+  const handleDelete = async () => {
+    if (deleteId === null) return
+    await fetch(`/api/feedback/${deleteId}`, { method: "DELETE" })
+    setShowDelete(false)
+    setDeleteId(null)
+    refresh()
+  }
+
+  const grouped = feedbacks.reduce((acc: Record<string, Feedback[]>, fb) => {
+    const date = new Date(fb.created_at).toLocaleDateString()
+    acc[date] = acc[date] || []
+    acc[date].push(fb)
+    return acc
+  }, {})
+
+  const formatTime = (dateStr: string) => {
+    return new Date(dateStr).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+  }
+
+  return (
+    <div className="min-h-screen bg-blue-900">
+      <main className="container mx-auto px-4 pb-24 pt-8">
+        <div className="max-w-3xl mx-auto space-y-6">
+          <h1 className="text-3xl font-bold text-white mb-4 glow-text">Feedbacks</h1>
+          {Object.entries(grouped).map(([date, items]) => (
+            <div key={date}>
+              <h2 className="text-xl text-blue-100 font-semibold mb-2">{date}</h2>
+              <div className="space-y-4">
+                {items.map((fb) => (
+                  <Card key={fb.id} className="bg-blue-800/30 border-blue-700/30 text-white">
+                    <CardHeader className="flex flex-row justify-between items-start">
+                      <CardTitle className="text-sm">{fb.username || "Anónimo"}</CardTitle>
+                      <div className="flex items-center gap-2">
+                        <span className="text-blue-300 text-xs">{formatTime(fb.created_at)}</span>
+                        <Button variant="ghost" size="icon" onClick={() => confirmDelete(fb.id)} aria-label="Eliminar">
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </CardHeader>
+                    <CardContent>
+                      <p className="whitespace-pre-wrap">{fb.message}</p>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </main>
+      <Dialog open={showDelete} onOpenChange={setShowDelete}>
+        <DialogContent className="bg-blue-800/90 border border-blue-700/50">
+          <DialogHeader>
+            <DialogTitle>Eliminar Feedback</DialogTitle>
+            <DialogDescription>
+              ¿Estás seguro de que deseas eliminar este feedback?
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="mt-4">
+            <Button variant="secondary" onClick={() => setShowDelete(false)}>
+              Cancelar
+            </Button>
+            <Button variant="destructive" onClick={handleDelete}>
+              Eliminar
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <NewNavbar />
+    </div>
+  )
+}

--- a/app/admin/juntify-changes/page.tsx
+++ b/app/admin/juntify-changes/page.tsx
@@ -1,13 +1,13 @@
-"use client";
+"use client"
 
-import { useEffect, useState, FormEvent } from "react";
-import { NewNavbar } from "@/components/new-navbar";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Edit, Trash2 } from "lucide-react";
+import { useEffect, useState, FormEvent } from "react"
+import { NewNavbar } from "@/components/new-navbar"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Edit, Trash2 } from "lucide-react"
 import {
   Dialog,
   DialogContent,
@@ -15,7 +15,8 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from "@/components/ui/dialog";
+} from "@/components/ui/dialog"
+
 
 function formatDescription(text: string) {
   const lines = text.split(/\r?\n/).filter((l) => l.trim() !== "");
@@ -45,94 +46,79 @@ function formatDescription(text: string) {
       ))}
     </>
   );
-  id: number;
-  version: string;
-  description: string;
+}
 
-  const [changes, setChanges] = useState<Change[]>([]);
-  const [version, setVersion] = useState("");
-  const [description, setDescription] = useState("");
-  const [error, setError] = useState("");
-  const [editingId, setEditingId] = useState<number | null>(null);
-  const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const [deleteId, setDeleteId] = useState<number | null>(null);
-    const res = await fetch("/api/juntify-changes");
-      const data = await res.json();
-      setChanges(data);
-  };
-    fetchChanges();
-  }, []);
-    e.preventDefault();
-      setError("Versión y descripción son requeridas");
-      return;
-      body: JSON.stringify({ version: version.trim(), description }),
-    });
-      setVersion("");
-      setDescription("");
-      setError("");
-      fetchChanges();
-      const data = await res.json();
-      setError(data.error || "Error al guardar");
-  };
-    e.preventDefault();
-    if (editingId === null) return;
-      setError("Versión y descripción son requeridas");
-      return;
-      body: JSON.stringify({ version: version.trim(), description }),
-    });
-      setVersion("");
-      setDescription("");
-      setEditingId(null);
-      setError("");
-      fetchChanges();
-      const data = await res.json();
-      setError(data.error || "Error al actualizar");
-  };
-    setDeleteId(id);
-    setShowDeleteModal(true);
-  };
-    if (deleteId === null) return;
-    });
-      fetchChanges();
-    setShowDeleteModal(false);
-    setDeleteId(null);
-  };
 
-    setEditingId(change.id);
-    setVersion(change.version);
-    setDescription(change.description);
-  };
-    setEditingId(null);
-    setVersion("");
-    setDescription("");
-    setError("");
-  };
-          <h1 className="text-3xl font-bold text-white mb-4 glow-text">
-            Cambios de Juntify
-          </h1>
-              <CardTitle>
-                {editingId ? "Editar Cambio" : "Nuevo Cambio"}
-              </CardTitle>
-                <Alert
-                  variant="destructive"
-                  className="mb-4 bg-red-900/40 border-red-800 text-white"
-                >
-              <form
-                onSubmit={editingId ? handleUpdate : handleCreate}
-                className="space-y-4"
-              >
-                  <Button
-                    type="submit"
-                    className="bg-blue-600 hover:bg-blue-700"
-                  >
-                    <td className="py-2 px-4 align-top whitespace-nowrap">
-                      {chg.version}
-                    </td>
-                    <td className="py-2 px-4 align-top whitespace-pre-wrap">
-                      {formatDescription(chg.description)}
-                    </td>
-  );
-      fetchChanges()
+interface Change {
+  id: number
+  version: string
+  description: string
+}
+
+export default function JuntifyChangesPage() {
+  const [changes, setChanges] = useState<Change[]>([])
+  const [version, setVersion] = useState("")
+  const [description, setDescription] = useState("")
+  const [error, setError] = useState("")
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [showDeleteModal, setShowDeleteModal] = useState(false)
+  const [deleteId, setDeleteId] = useState<number | null>(null)
+
+  const refreshChanges = async () => {
+    const res = await fetch("/api/juntify-changes")
+    if (res.ok) {
+      const data = await res.json()
+      setChanges(data)
+    }
+  }
+
+  useEffect(() => {
+    async function fetchChanges() {
+      await refreshChanges()
+    }
+    fetchChanges()
+  }, [])
+
+  const handleCreate = async (e: FormEvent) => {
+    e.preventDefault()
+    if (!version.trim() || !description.trim()) {
+      setError("Versión y descripción son requeridas")
+      return
+    }
+    const res = await fetch("/api/juntify-changes", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: version.trim(), description })
+    })
+    if (res.ok) {
+      setVersion("")
+      setDescription("")
+      setError("")
+      refreshChanges()
+    } else {
+      const data = await res.json()
+      setError(data.error || "Error al guardar")
+    }
+  }
+
+  const handleUpdate = async (e: FormEvent) => {
+    e.preventDefault()
+    if (editingId === null) return
+    if (!version.trim() || !description.trim()) {
+      setError("Versión y descripción son requeridas")
+      return
+    }
+    const res = await fetch(`/api/juntify-changes/${editingId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ version: version.trim(), description })
+    })
+    if (res.ok) {
+      setVersion("")
+      setDescription("")
+      setEditingId(null)
+      setError("")
+      refreshChanges()
     } else {
       const data = await res.json()
       setError(data.error || "Error al actualizar")
@@ -150,7 +136,7 @@ function formatDescription(text: string) {
       method: "DELETE",
     })
     if (res.ok) {
-      fetchChanges()
+      refreshChanges()
     }
     setShowDeleteModal(false)
     setDeleteId(null)
@@ -228,7 +214,7 @@ function formatDescription(text: string) {
                   <tr key={chg.id} className="border-t border-blue-700/30">
 
                     <td className="py-2 px-4 align-top whitespace-nowrap">{chg.version}</td>
-                    <td className="py-2 px-4 align-top whitespace-pre-wrap">{highlightNotes(chg.description)}</td>
+                    <td className="py-2 px-4 align-top whitespace-pre-wrap">{formatDescription(chg.description)}</td>
                     <td className="py-2 px-4">
 
                       <div className="flex items-center gap-2">

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -19,7 +19,7 @@ import {
 
 export default function AdminPage() {
   const options = [
-    { title: "Feedbacks", icon: MessageSquare, available: false },
+    { title: "Feedbacks", icon: MessageSquare, available: true, href: "/admin/feedbacks" },
     {
       title: "Cambios de Juntify",
       icon: History,

--- a/app/api/feedback/[id]/route.ts
+++ b/app/api/feedback/[id]/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server"
+import { feedbackService } from "@/services/feedbackService"
+
+export async function DELETE(request: Request, { params }: { params: { id: string } }) {
+  try {
+    const id = Number.parseInt(params.id)
+    if (isNaN(id)) {
+      return NextResponse.json({ error: "Invalid id" }, { status: 400 })
+    }
+    const success = await feedbackService.deleteFeedback(id)
+    if (!success) {
+      return NextResponse.json({ error: "Feedback not found" }, { status: 404 })
+    }
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error("Error deleting feedback:", error)
+    return NextResponse.json({ error: "Error interno" }, { status: 500 })
+  }
+}

--- a/app/api/feedback/route.tsx
+++ b/app/api/feedback/route.tsx
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import { query } from "@/utils/mysql"
 import { getUsernameFromRequest } from "@/utils/user-helpers"
+import { feedbackService } from "@/services/feedbackService"
 
 export async function POST(request: Request) {
   try {
@@ -18,6 +19,16 @@ export async function POST(request: Request) {
     return NextResponse.json({ success: true })
   } catch (error) {
     console.error("Error guardando feedback:", error)
+    return NextResponse.json({ error: "Error interno" }, { status: 500 })
+  }
+}
+
+export async function GET() {
+  try {
+    const feedbacks = await feedbackService.getAll()
+    return NextResponse.json(feedbacks)
+  } catch (error) {
+    console.error("Error fetching feedbacks:", error)
     return NextResponse.json({ error: "Error interno" }, { status: 500 })
   }
 }

--- a/services/feedbackService.ts
+++ b/services/feedbackService.ts
@@ -1,0 +1,31 @@
+import { query } from "@/utils/mysql"
+
+export interface Feedback {
+  id: number
+  username: string | null
+  message: string
+  created_at: Date
+}
+
+export const feedbackService = {
+  async getAll(): Promise<Feedback[]> {
+    try {
+      return await query<Feedback>(
+        "SELECT id, username, message, created_at FROM feedback ORDER BY created_at DESC"
+      )
+    } catch (error) {
+      console.error("Error fetching feedbacks:", error)
+      return []
+    }
+  },
+
+  async deleteFeedback(id: number): Promise<boolean> {
+    try {
+      const result = await query("DELETE FROM feedback WHERE id = ?", [id])
+      return result.affectedRows > 0
+    } catch (error) {
+      console.error("Error deleting feedback:", error)
+      return false
+    }
+  },
+}


### PR DESCRIPTION
## Summary
- fix corrupted admin page component
- move fetch logic to `refreshChanges` and call from `useEffect`
- format change descriptions as bullet lists
- list feedbacks grouped by date and allow deletion
- add API routes and service for feedback management
- enable feedback admin page link

## Testing
- `npx tsc --noEmit app/admin/feedbacks/page.tsx app/api/feedback/route.tsx app/api/feedback/[id]/route.ts services/feedbackService.ts` *(fails: missing libs)*

------
https://chatgpt.com/codex/tasks/task_e_684a42880358832080b5b172839d1149