### PR TITLE
Add bcryptjs and simple auth routes

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server"
+import { queryOne } from "@/utils/mysql"
+import bcrypt from "bcryptjs"
+
+export async function POST(request: Request) {
+  try {
+    const { username, password } = await request.json()
+    if (!username || !password) {
+      return NextResponse.json({ error: "Missing fields" }, { status: 400 })
+    }
+
+    const user = await queryOne(
+      "SELECT * FROM users WHERE username = ?",
+      [username],
+    )
+
+    if (!user) {
+      return NextResponse.json({ error: "Invalid credentials" }, { status: 401 })
+    }
+
+    const valid = await bcrypt.compare(password, user.password)
+    if (!valid) {
+      return NextResponse.json({ error: "Invalid credentials" }, { status: 401 })
+    }
+
+    return NextResponse.json({ message: "Login successful" })
+  } catch (error) {
+    console.error("Error logging in:", error)
+    return NextResponse.json({ error: "Error logging in" }, { status: 500 })
+  }
+}

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server"
+import { query } from "@/utils/mysql"
+import bcrypt from "bcryptjs"
+
+export async function POST(request: Request) {
+  try {
+    const { username, email, password } = await request.json()
+    if (!username || !email || !password) {
+      return NextResponse.json({ error: "Missing fields" }, { status: 400 })
+    }
+
+    const hash = await bcrypt.hash(password, 10)
+    await query(
+      "INSERT INTO users (username, email, password) VALUES (?, ?, ?)",
+      [username, email, hash],
+    )
+
+    return NextResponse.json({ message: "Usuario registrado" }, { status: 201 })
+  } catch (error) {
+    console.error("Error registrando usuario:", error)
+    return NextResponse.json({ error: "Error registering user" }, { status: 500 })
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@vercel/postgres": "latest",
         "ai": "latest",
         "autoprefixer": "^10.4.20",
+        "bcryptjs": "^3.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "1.0.4",
@@ -6045,6 +6046,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
     },
     "node_modules/bignumber.js": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@vercel/postgres": "latest",
     "ai": "latest",
     "autoprefixer": "^10.4.20",
+    "bcryptjs": "^3.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "1.0.4",


### PR DESCRIPTION
## Summary
- add `bcryptjs` dependency
- add basic auth login & register routes hashing passwords

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails with multiple react/no-unescaped-entities errors)*

------
https://chatgpt.com/codex/tasks/task_e_684b335c93ec8320b909d53ca94d1077