### PR TITLE
Fix login page try-catch structure

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -289,8 +289,6 @@ export default function LoginPage() {
             // } else {
             //   console.warn("Facebook Pixel (fbq) not found. Make sure the base code is loaded.");
             // }
-          }
-
           setSuccess("¡Cuenta creada exitosamente! Ahora puedes iniciar sesión.")
 
           // Limpiar formulario y cambiar a inicio de sesión
@@ -302,6 +300,7 @@ export default function LoginPage() {
             setGroupCode("")
             setIsLogin(true)
           }, 2000)
+          }
         } catch (error: any) {
           // Verificar si el error es de username duplicado
           if (error.message?.includes("duplicate key") && error.message?.includes("username")) {


### PR DESCRIPTION
## Summary
- move success and timeout logic inside the register `try` block to fix syntax errors

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_684b375a54188320848d9a7b12129c45