### PR TITLE
Fix login route and default role

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,18 +1,19 @@
 import { NextResponse } from "next/server"
 import { queryOne } from "@/utils/mysql"
 import bcrypt from "bcryptjs"
+
 export async function POST(request: Request) {
   try {
-    const { username, password } = await request.json()
+    const { email, username, password } = await request.json()
 
-    if (!username || !password) {
+    if ((!email && !username) || !password) {
       return NextResponse.json({ error: "Missing fields" }, { status: 400 })
     }
 
-    const user = await queryOne(
-      "SELECT * FROM users WHERE username = ?",
-      [username],
-    )
+    // Permitir iniciar sesión con email o username
+    const user = email
+      ? await queryOne("SELECT * FROM users WHERE email = ?", [email])
+      : await queryOne("SELECT * FROM users WHERE username = ?", [username])
 
     if (!user) {
       return NextResponse.json({ error: "Invalid credentials" }, { status: 401 })
@@ -23,10 +24,9 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Invalid credentials" }, { status: 401 })
     }
 
-    return NextResponse.json({ message: "Login successful" })
+    return NextResponse.json({ message: "Login successful", username: user.username })
   } catch (error) {
     console.error("Error logging in:", error)
     return NextResponse.json({ error: "Error logging in" }, { status: 500 })
-
   }
 }

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -12,8 +12,8 @@ export async function POST(request: Request) {
 
     const hash = await bcrypt.hash(password, 10)
     await query(
-      "INSERT INTO users (username, email, password) VALUES (?, ?, ?)",
-      [username, email, hash],
+      "INSERT INTO users (username, email, password, role) VALUES (?, ?, ?, ?)",
+      [username, email, hash, "free"],
     )
 
     return NextResponse.json({ message: "Usuario registrado" }, { status: 201 })

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -289,8 +289,6 @@ export default function LoginPage() {
             // } else {
             //   console.warn("Facebook Pixel (fbq) not found. Make sure the base code is loaded.");
             // }
-          }
-
           setSuccess("¡Cuenta creada exitosamente! Ahora puedes iniciar sesión.")
 
           // Limpiar formulario y cambiar a inicio de sesión
@@ -301,7 +299,7 @@ export default function LoginPage() {
             setPassword("")
             setGroupCode("")
             setIsLogin(true)
-          }, 2000)
+          }, 2000);
         } catch (error: any) {
           // Verificar si el error es de username duplicado
           if (error.message?.includes("duplicate key") && error.message?.includes("username")) {


### PR DESCRIPTION
## Summary
- allow email-based login
- always assign `free` role when registering new users

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json` *(fails in components/ai-chat-modal.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_684b375a54188320848d9a7b12129c45