### PR TITLE
Implement JWT issuance on login

### DIFF
--- a/__tests__/login.test.ts
+++ b/__tests__/login.test.ts
@@ -1,0 +1,58 @@
+jest.mock('../utils/mysql', () => ({
+  queryOne: jest.fn()
+}))
+
+jest.mock('bcryptjs', () => ({
+  compare: jest.fn(async () => true)
+}))
+
+jest.mock('jose', () => ({
+  SignJWT: jest.fn().mockImplementation(() => ({
+    setProtectedHeader() { return this },
+    setExpirationTime() { return this },
+    sign: jest.fn(async () => 'signed-token')
+  }))
+}))
+
+const { POST } = require('../app/api/auth/login/route')
+
+const mockUser = {
+  id: 'user-id',
+  username: 'testuser',
+  full_name: 'Test User',
+  email: 'test@example.com',
+  password: 'hashed',
+  roles: 'free',
+  organization: null
+}
+
+describe('login route', () => {
+  it('returns token and user info', async () => {
+    process.env.JWT_SECRET = 'secret'
+    const queryOne = require('../utils/mysql').queryOne as jest.Mock
+    queryOne.mockResolvedValue(mockUser)
+
+    const body = { email: 'test@example.com', password: 'pass' }
+    const req = { json: async () => body } as unknown as Request
+
+    const res = await POST(req)
+
+    expect(queryOne).toHaveBeenCalledWith(
+      expect.stringContaining('WHERE email = ?'),
+      [body.email]
+    )
+
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.user).toMatchObject({
+      id: mockUser.id,
+      username: mockUser.username,
+      full_name: mockUser.full_name,
+      email: mockUser.email,
+      roles: mockUser.roles,
+      organization: mockUser.organization
+    })
+    expect(typeof data.token).toBe('string')
+    expect(data.token.length).toBeGreaterThan(0)
+  })
+})

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import { queryOne } from "@/utils/mysql"
 import bcrypt from "bcryptjs"
+import { SignJWT } from "jose"
 
 export async function POST(request: Request) {
   try {
@@ -24,7 +25,24 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Invalid credentials" }, { status: 401 })
     }
 
-    return NextResponse.json({ message: "Login successful", username: user.username })
+    const secret = new TextEncoder().encode(process.env.JWT_SECRET as string)
+    const token = await new SignJWT({ id: user.id, username: user.username })
+      .setProtectedHeader({ alg: "HS256" })
+      .setExpirationTime("7d")
+      .sign(secret)
+
+    const userInfo = {
+      id: user.id,
+      username: user.username,
+      full_name: user.full_name,
+      email: user.email,
+      roles: user.roles,
+      organization: user.organization,
+    }
+
+    const response = NextResponse.json({ token, user: userInfo }, { status: 200 })
+    response.cookies.set("auth_token", token, { httpOnly: true, path: "/" })
+    return response
   } catch (error) {
     console.error("Error logging in:", error)
     return NextResponse.json({ error: "Error logging in" }, { status: 500 })


### PR DESCRIPTION
## Summary
- sign JWT token in login route and set cookie
- add Jest test for login JWT generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b42e333e483208632a7707d434fa9