### PR TITLE
Add auth check in middleware

### DIFF
--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -1,0 +1,38 @@
+jest.mock('jose', () => ({
+  jwtVerify: jest.fn(),
+}))
+
+import { jwtVerify } from 'jose'
+import { middleware } from '../middleware'
+import { NextRequest } from 'next/server'
+
+describe('middleware', () => {
+  beforeEach(() => {
+    ;(jwtVerify as jest.Mock).mockReset()
+  })
+
+  it('blocks requests without token', async () => {
+    const req = new NextRequest('http://localhost/api/containers')
+    const res = await middleware(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('blocks requests with invalid token', async () => {
+    ;(jwtVerify as jest.Mock).mockRejectedValue(new Error('invalid'))
+    const req = new NextRequest('http://localhost/api/containers', {
+      headers: { cookie: 'auth_token=bad' },
+    })
+    const res = await middleware(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('injects username for valid token', async () => {
+    ;(jwtVerify as jest.Mock).mockResolvedValue({ payload: { username: 'alice' } })
+    const req = new NextRequest('http://localhost/api/containers', {
+      headers: { cookie: 'auth_token=good' },
+    })
+    const res = await middleware(req)
+    expect(res.status).toBe(200)
+    expect(req.headers.get('X-Username')).toBe('alice')
+  })
+})

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,21 +2,30 @@ import { NextRequest, NextResponse } from "next/server";
 import { jwtVerify } from "jose";
 
 export async function middleware(req: NextRequest) {
-  const token = req.cookies.get("auth_token")?.value;
-  if (token) {
-    try {
-      const { payload } = await jwtVerify(
-        token,
-        new TextEncoder().encode(process.env.JWT_SECRET as string)
-      );
-      const username = (payload as any).username;
-      if (username) {
-        req.headers.set("X-Username", String(username));
-      }
-    } catch (err) {
-      console.error("JWT verification failed", err);
-    }
+  const { pathname } = req.nextUrl;
+  if (pathname.startsWith("/api/auth")) {
+    return NextResponse.next();
   }
+
+  const token = req.cookies.get("auth_token")?.value;
+  if (!token) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { payload } = await jwtVerify(
+      token,
+      new TextEncoder().encode(process.env.JWT_SECRET as string)
+    );
+    const username = (payload as any).username;
+    if (username) {
+      req.headers.set("X-Username", String(username));
+    }
+  } catch (err) {
+    console.error("JWT verification failed", err);
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   return NextResponse.next({ request: { headers: req.headers } });
 }
 


### PR DESCRIPTION
## Summary
- return 401 for protected API routes when token verification fails
- allow auth routes to bypass check
- test middleware behavior on bad and good tokens

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684b4cbdc7288320a474b633ca9d9fc2