### PR TITLE
Ensure username header sent for Google Drive endpoints

### DIFF
--- a/components/google-drive-setup.tsx
+++ b/components/google-drive-setup.tsx
@@ -113,6 +113,7 @@ export function GoogleDriveSetup() {
       console.log("Verificando conexión para el usuario:", user)
       const response = await fetch("/api/auth/google/status", {
         headers: {
+          "X-Username": user,
         },
       })
 
@@ -230,6 +231,7 @@ export function GoogleDriveSetup() {
       const response = await fetch("/api/auth/google/disconnect", {
         method: "POST",
         headers: {
+          "X-Username": username,
         },
       })
 
@@ -311,6 +313,7 @@ export function GoogleDriveSetup() {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          "X-Username": username,
         },
         body: JSON.stringify({ folderId }),
       })


### PR DESCRIPTION
## Summary
- add `X-Username` header when checking Drive connection
- add `X-Username` header for disconnect and save folder actions

## Testing
- `npm test`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684b789070e483209c64802efecea1d7