### PR TITLE
Add welcome email on user registration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Database configuration
+DATABASE_HOST=localhost
+DATABASE_USER=root
+DATABASE_PASSWORD=pass
+DATABASE_NAME=juntify
+DATABASE_PORT=3306
+
+# JWT secret
+JWT_SECRET=changeme
+
+# SMTP configuration for welcome emails
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=user@example.com
+SMTP_PASS=securepass
+EMAIL_FROM="Juntify <no-reply@example.com>"

--- a/__tests__/register.test.ts
+++ b/__tests__/register.test.ts
@@ -2,6 +2,10 @@ jest.mock('../utils/mysql', () => ({
   query: jest.fn().mockResolvedValue(null)
 }))
 
+jest.mock('../utils/email', () => ({
+  sendWelcomeEmail: jest.fn().mockResolvedValue(undefined)
+}))
+
 jest.mock('uuid', () => ({
   v4: jest.fn(() => 'test-uuid')
 }))
@@ -60,5 +64,8 @@ describe('register route', () => {
     })
     expect(typeof data.token).toBe('string')
     expect(data.token.length).toBeGreaterThan(0)
+
+    const { sendWelcomeEmail } = require('../utils/email')
+    expect(sendWelcomeEmail).toHaveBeenCalledWith(body.email, body.full_name)
   })
 })

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -4,6 +4,7 @@ import { query } from "@/utils/mysql"
 import bcrypt from "bcryptjs"
 import { v4 as uuidv4 } from "uuid"
 import { SignJWT } from "jose"
+import { sendWelcomeEmail } from "@/utils/email"
 
 export async function POST(request: Request) {
   try {
@@ -36,6 +37,11 @@ export async function POST(request: Request) {
       roles: "free",
       organization: null,
     }
+
+    // Send welcome email but don't fail the request if sending fails
+    sendWelcomeEmail(email, full_name || username).catch((err) => {
+      console.error("Welcome email failed", err)
+    })
 
     const response = NextResponse.json({ token, user }, { status: 201 })
     response.cookies.set("auth_token", token, { httpOnly: true, path: "/" })

--- a/utils/email.ts
+++ b/utils/email.ts
@@ -1,0 +1,40 @@
+import nodemailer from "nodemailer"
+
+let transporter: nodemailer.Transporter | null = null
+
+function getTransporter(): nodemailer.Transporter {
+  if (!transporter) {
+    transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: process.env.SMTP_PORT ? Number(process.env.SMTP_PORT) : 587,
+      secure: process.env.SMTP_PORT === "465",
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    })
+  }
+  return transporter
+}
+
+export async function sendWelcomeEmail(to: string, name: string): Promise<void> {
+  try {
+    const transport = getTransporter()
+    const html = `
+      <div style="font-family:sans-serif;color:#003d7a">
+        <h1 style="color:#0066cc">Juntify</h1>
+        <p>Hola ${name},</p>
+        <p>\u00a1Bienvenido a <strong>Juntify</strong>! Nos alegra tenerte con nosotros.</p>
+        <p>Comienza a gestionar tus reuniones de manera eficiente.</p>
+      </div>
+    `
+    await transport.sendMail({
+      from: process.env.EMAIL_FROM,
+      to,
+      subject: "Juntify",
+      html,
+    })
+  } catch (err) {
+    console.error("Error sending welcome email:", err)
+  }
+}


### PR DESCRIPTION
## Summary
- send a welcome email after a user registers
- provide SMTP config example
- test that welcome email is triggered

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b84aaef7c83208b8349a288b0ca13