### PR TITLE
Fix audio-file route to detect WebM recordings

### DIFF
--- a/app/api/meetings/[id]/audio-file/route.ts
+++ b/app/api/meetings/[id]/audio-file/route.ts
@@ -105,10 +105,12 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
       const name = file.name || ""
       return (
         mimeType.includes("audio/") ||
+        mimeType === "video/webm" ||
         name.endsWith(".aac") ||
         name.endsWith(".mp3") ||
         name.endsWith(".wav") ||
-        name.endsWith(".m4a")
+        name.endsWith(".m4a") ||
+        name.endsWith(".webm")
       )
     })
 


### PR DESCRIPTION
## Summary
- handle `video/webm` and `.webm` names when scanning Google Drive files

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails due to dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_684b9a7839bc832087e4842bcb61da7e