### PR TITLE
Fix fetchTranscription header

### DIFF
--- a/app/building-transcriptions/page.tsx
+++ b/app/building-transcriptions/page.tsx
@@ -314,6 +314,7 @@ export default function BuildingTranscriptionPage() {
     try {
       const response = await fetch(`/api/meetings/${id}`, {
         headers: {
+          "X-Username": username,
         },
       })
 


### PR DESCRIPTION
## Summary
- ensure the transcription request sends the username header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b9d693ee48320bc22abdb8c7b8482