### PR TITLE
Include auth_token cookie for audio fetch

### DIFF
--- a/app/api/meetings/[id]/audio-direct-download/route.ts
+++ b/app/api/meetings/[id]/audio-direct-download/route.ts
@@ -17,12 +17,19 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
 
     console.log(`Descargando audio para la reunión ${meetingId} del usuario ${username}`)
 
+    // Obtener el token de autenticación de las cookies
+    const token = request.cookies.get("auth_token")?.value
+
     // Obtener información del archivo de audio
-    const infoResponse = await fetch(`${request.nextUrl.origin}/api/meetings/${meetingId}/audio-file`, {
-      headers: {
-        "X-Username": username,
+    const infoResponse = await fetch(
+      `${request.nextUrl.origin}/api/meetings/${meetingId}/audio-file`,
+      {
+        headers: {
+          "X-Username": username,
+          ...(token ? { Cookie: `auth_token=${token}` } : {}),
+        },
       },
-    })
+    )
 
     if (!infoResponse.ok) {
       const errorData = await infoResponse.json()

--- a/app/api/meetings/[id]/audio-download/route.ts
+++ b/app/api/meetings/[id]/audio-download/route.ts
@@ -17,12 +17,19 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
 
     console.log(`Descargando audio para la reunión ${meetingId} del usuario ${username}`)
 
+    // Obtener el token de autenticación de las cookies
+    const token = request.cookies.get("auth_token")?.value
+
     // Obtener información del archivo de audio
-    const infoResponse = await fetch(`${request.nextUrl.origin}/api/meetings/${meetingId}/audio-file`, {
-      headers: {
-        "X-Username": username,
+    const infoResponse = await fetch(
+      `${request.nextUrl.origin}/api/meetings/${meetingId}/audio-file`,
+      {
+        headers: {
+          "X-Username": username,
+          ...(token ? { Cookie: `auth_token=${token}` } : {}),
+        },
       },
-    })
+    )
 
     if (!infoResponse.ok) {
       const errorData = await infoResponse.json()


### PR DESCRIPTION
## Summary
- fetch the auth token from cookies
- send this cookie along with username header when requesting audio info

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684ba2287d588320893179c501f92d1a