### PR TITLE
Add shared meeting wrappers

### DIFF
--- a/resources/views/reuniones.blade.php
+++ b/resources/views/reuniones.blade.php
@@ -121,8 +121,16 @@
                         @endisset
                     </div>
 
-                    <div id="shared-meetings" class="hidden">
-                        <div class="loading-card"><p>No hay reuniones compartidas</p></div>
+                    <div id="shared-meetings" class="hidden space-y-6">
+                        <div id="incoming-shared-wrapper" class="loading-card">
+                            <div class="loading-spinner"></div>
+                            <p>Cargando reuniones compartidas contigo...</p>
+                        </div>
+
+                        <div id="outgoing-shared-wrapper" class="loading-card">
+                            <div class="loading-spinner"></div>
+                            <p>Cargando reuniones que has compartido...</p>
+                        </div>
                     </div>
 
                     <div id="containers" class="hidden">


### PR DESCRIPTION
## Summary
- add dedicated containers for incoming and outgoing shared meetings placeholders in the shared meetings tab
- ensure the existing loaders render into the new container ids for accepted and user-shared meetings

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c8bd214e1483238bedab7a69ec2af8