### PR TITLE
Increase meeting modal z-index

### DIFF
--- a/resources/views/organization/index.blade.php
+++ b/resources/views/organization/index.blade.php
@@ -935,7 +935,7 @@
 </x-modal>
 
 <!-- Modal para ver reunión -->
-<div id="meeting-modal" class="fixed inset-0 bg-black/50 flex items-center justify-center z-70 hidden">
+<div id="meeting-modal" class="fixed inset-0 bg-black/50 flex items-center justify-center z-[80] hidden">
     <div class="bg-slate-900 rounded-lg w-full max-w-4xl max-h-[80vh] overflow-hidden border border-slate-700">
         <!-- Header del modal -->
         <div class="flex items-center justify-between p-6 border-b border-slate-700">


### PR DESCRIPTION
## Summary
- elevate the conversation meeting modal layer so it appears above other overlays
- confirmed group and container modals retain their lower z-index ranges

## Testing
- ⚠️ `php artisan serve --host=0.0.0.0 --port=8000` *(fails: missing vendor directory before installing dependencies)*
- ⚠️ `composer install` *(fails: GitHub API 403 when attempting to fetch packages without token)*

------
https://chatgpt.com/codex/tasks/task_e_68c8c4753c20832396beba355278b982