### PR TITLE
Increase modal z-index and adjust overlays

### DIFF
--- a/resources/js/reuniones_v2.js
+++ b/resources/js/reuniones_v2.js
@@ -913,7 +913,7 @@ function showNotification(message, type = 'info') {
         container.style.display = 'flex';
         container.style.flexDirection = 'column';
         container.style.gap = '10px';
-        container.style.zIndex = '9999';
+        container.style.zIndex = '9500';
         container.style.pointerEvents = 'none';
         document.body.appendChild(container);
     }
@@ -4259,7 +4259,7 @@ function showDownloadFallbackModal(meetingId, message, directLinks = null) {
     }
 
     const html = `
-        <div class="fixed inset-0 z-[9999] overflow-hidden" id="downloadFallbackModal">
+        <div class="fixed inset-0 z-[9500] overflow-hidden" id="downloadFallbackModal">
             <div class="fixed inset-0 bg-black bg-opacity-60 backdrop-blur-sm"></div>
             <div class="fixed inset-0 flex items-center justify-center">
                 <div class="relative bg-slate-800 rounded-xl shadow-2xl w-full max-w-md mx-4 border border-slate-700 p-6">
@@ -4308,7 +4308,7 @@ async function tryResolveSharedDriveLinks(sharedMeetingId) {
 function showDownloadModalLoading(meetingId) {
     // Crear y mostrar modal de loading centrado perfectamente
     const loadingModal = `
-        <div class="fixed inset-0 z-[9999] overflow-hidden" id="downloadLoadingModal">
+        <div class="fixed inset-0 z-[9500] overflow-hidden" id="downloadLoadingModal">
             <!-- Overlay -->
             <div class="fixed inset-0 bg-black bg-opacity-60 backdrop-blur-sm"></div>
 
@@ -4388,7 +4388,7 @@ function createDownloadModal() {
              x-on:close.stop="show = false"
              x-on:keydown.escape.window="show = false"
              name="download-meeting"
-             class="fixed inset-0 z-[9999] overflow-hidden download-modal"
+             class="fixed inset-0 z-[9500] overflow-hidden download-modal"
              style="display: none;">
 
             <!-- Overlay con fondo semi-transparente -->

--- a/resources/js/utils/alerts.js
+++ b/resources/js/utils/alerts.js
@@ -11,7 +11,7 @@ function ensureToastContainer() {
         container.style.display = 'flex';
         container.style.flexDirection = 'column';
         container.style.gap = '10px';
-        container.style.zIndex = '9999';
+        container.style.zIndex = '9500';
         container.style.pointerEvents = 'none';
         document.body.appendChild(container);
     }

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -46,7 +46,7 @@ $maxWidth = [
     x-on:keydown.tab.prevent="$event.shiftKey || nextFocusable().focus()"
     x-on:keydown.shift.tab.prevent="prevFocusable().focus()"
     x-show="show"
-    class="fixed inset-0 flex items-center justify-center overflow-y-auto px-4 sm:px-0 z-50"
+    class="fixed inset-0 flex items-center justify-center overflow-y-auto px-4 sm:px-0 z-[9999]"
     style="display: {{ $show ? 'block' : 'none' }};"
 >
     <div

--- a/resources/views/components/share-modal.blade.php
+++ b/resources/views/components/share-modal.blade.php
@@ -1,4 +1,4 @@
-<div id="shareModal" class="modal hidden" style="z-index: 9999;">
+<div id="shareModal" class="modal hidden" style="z-index: 9500;">
     <div class="modal-content max-w-md">
         <div class="modal-header">
             <h3 class="modal-title">

--- a/resources/views/contacts/index.blade.php
+++ b/resources/views/contacts/index.blade.php
@@ -138,7 +138,7 @@
 </div>
 
 <!-- Modal de Chat -->
-<div id="chat-modal" class="fixed inset-0 z-[9999] hidden items-center justify-center bg-black/30 backdrop-blur-sm opacity-0 transition-all duration-300 p-6">
+<div id="chat-modal" class="fixed inset-0 z-[9500] hidden items-center justify-center bg-black/30 backdrop-blur-sm opacity-0 transition-all duration-300 p-6">
     <div class="bg-slate-900/85 backdrop-blur-xl border border-slate-700/40 rounded-xl w-full max-w-4xl h-auto max-h-[80vh] shadow-2xl flex flex-col transform scale-95 transition-all duration-300 my-auto">
         <!-- Header del Modal -->
         <div class="flex items-center justify-between p-6 border-b border-slate-700/50">

--- a/resources/views/profile.blade.php
+++ b/resources/views/profile.blade.php
@@ -129,7 +129,7 @@
             border-radius: 12px;
             color: white;
             font-weight: 500;
-            z-index: 9999;
+            z-index: 9500;
             min-width: 300px;
             max-width: 500px;
             box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
@@ -235,7 +235,7 @@
             border-radius: 8px;
             color: white;
             font-weight: 500;
-            z-index: 9999;
+            z-index: 9500;
             opacity: 0;
             transform: translateX(100%);
             transition: all 0.3s ease;


### PR DESCRIPTION
## Summary
- raise the shared modal component to use a z-index of 9999 so it can overlay the entire app
- lower other ad-hoc overlays and toast containers so their stacking order stays below the main modal layer

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c8c5fd6acc8323baffa7ab55817012