### PR TITLE
Handle shared meeting links in modals

### DIFF
--- a/resources/js/reuniones_v2.js
+++ b/resources/js/reuniones_v2.js
@@ -2117,7 +2117,12 @@ function attachMeetingEventListeners() {
         if (downloadBtn) {
             downloadBtn.addEventListener('click', (e) => {
                 e.stopPropagation();
-                openDownloadModal(card.dataset.meetingId);
+                const sharedId = card.dataset.sharedId;
+                if (sharedId) {
+                    openDownloadModal(card.dataset.meetingId, sharedId);
+                } else {
+                    openDownloadModal(card.dataset.meetingId);
+                }
             });
         }
         const shareBtn = card.querySelector('.share-btn');
@@ -2137,7 +2142,8 @@ function attachMeetingEventListeners() {
             if (containerModal && !containerModal.classList.contains('hidden')) {
                 openMeetingModalFromContainer(meetingId);
             } else {
-                openMeetingModal(meetingId);
+                const sharedId = this.dataset.sharedId || null;
+                openMeetingModal(meetingId, sharedId);
             }
         });
     });
@@ -2386,7 +2392,7 @@ function closeContainerSelectModal() {
 // ===============================================
 // MODAL DE REUNIÓN
 // ===============================================
-async function openMeetingModal(meetingId) {
+async function openMeetingModal(meetingId, sharedMeetingId = null) {
     try {
         // Mostrar modal de loading inmediatamente
         showModalLoadingState();
@@ -2442,6 +2448,14 @@ async function openMeetingModal(meetingId) {
 
             // Esperar un poco para mostrar el progreso completo
             await new Promise(resolve => setTimeout(resolve, 500));
+
+            if (sharedMeetingId) {
+                const resolvedLinks = await tryResolveSharedDriveLinks(sharedMeetingId);
+                if (resolvedLinks && resolvedLinks.audio_link) {
+                    meeting.audio_path = resolvedLinks.audio_link;
+                }
+                meeting.shared_meeting_id = sharedMeetingId;
+            }
 
             currentModalMeeting = meeting;
             // Guardar bandera de encriptación


### PR DESCRIPTION
## Summary
- update meeting card event handlers to include shared meeting context for downloads and modal opening
- allow meeting modal to resolve shared drive audio links and retain shared meeting id metadata

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8c9f52d908323b4bb4edf20bd33b7