### PR TITLE
Fix PDF download headers

### DIFF
--- a/resources/js/reuniones_v2.js
+++ b/resources/js/reuniones_v2.js
@@ -4671,6 +4671,14 @@ function initializeDownloadModal() {
                     return;
                 }
 
+                const csrfMeta = document.querySelector('meta[name="csrf-token"]');
+                const csrfToken = csrfMeta?.getAttribute('content');
+
+                if (!csrfToken) {
+                    alert('Error: No se encontró el token CSRF.');
+                    return;
+                }
+
                 // Mostrar loading en el botón con mejor UI
                 confirm.disabled = true;
                 originalContent = confirm.innerHTML;
@@ -4705,8 +4713,8 @@ function initializeDownloadModal() {
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json',
-                            'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
-                            'Accept': 'application/json',
+                            'X-CSRF-TOKEN': csrfToken,
+                            'Accept': 'application/pdf',
                         },
                         body: JSON.stringify(downloadData)
                     });


### PR DESCRIPTION
## Summary
- validate CSRF meta tag before triggering PDF download
- reuse the retrieved token with optional chaining when building headers
- request the PDF from the API by setting the Accept header to application/pdf

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c8d70b35b08323b1e8f84722b95967