### PR TITLE
Ensure full preview modal uses flex layout

### DIFF
--- a/resources/views/reuniones.blade.php
+++ b/resources/views/reuniones.blade.php
@@ -151,7 +151,7 @@
     {{-- El resto de tus modales no necesita cambios para esta tarea --}}
 
     <div id="fullPreviewModal"
-        class="fixed inset-0 z-[9999] hidden items-center justify-center bg-slate-950/80 backdrop-blur-sm px-4 py-8">
+        class="fixed inset-0 z-[9999] hidden flex items-center justify-center bg-slate-950/80 backdrop-blur-sm px-4 py-8">
         <div class="relative w-full max-w-5xl h-full max-h-[90vh] bg-slate-900 border border-slate-700/60 rounded-2xl shadow-2xl overflow-hidden">
             <button id="closeFullPreview" type="button"
                 class="absolute top-4 right-4 inline-flex items-center justify-center w-10 h-10 rounded-full bg-slate-800/70 border border-slate-700/70 text-slate-300 hover:bg-slate-700/70 hover:text-white transition">


### PR DESCRIPTION
## Summary
- add the flex utility class to the full preview modal overlay so it can center its contents

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8e16f3eac8323a8b4f49570c3a23a