### PR TITLE
Adjust PDF preview frame parameters

### DIFF
--- a/resources/js/reuniones_v2.js
+++ b/resources/js/reuniones_v2.js
@@ -4543,7 +4543,7 @@ function openFullPreviewModal(url) {
     ensurePreviewModal();
     const modal = document.getElementById('fullPreviewModal');
     const frame = document.getElementById('fullPreviewFrame');
-    frame.src = url;
+    frame.src = url + '#navpanes=0&zoom=page-width';
     modal.classList.remove('hidden');
 }
 


### PR DESCRIPTION
## Summary
- append PDF viewer parameters so the full preview hides navigation panes and fits the available width

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8e2160bd0832384acbb83ced0bbb7