### PR TITLE
Implement document processing pipeline services

### DIFF
--- a/app/Http/Controllers/AiAssistantController.php
+++ b/app/Http/Controllers/AiAssistantController.php
@@ -14,11 +14,10 @@ use App\Models\Contact;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use App\Services\AiChatService;
+use App\Jobs\ProcessAiDocumentJob;
 use App\Services\EmbeddingSearch;
 
 class AiAssistantController extends Controller
@@ -546,13 +545,11 @@ class AiAssistantController extends Controller
      */
     private function processDocumentInBackground(AiDocument $document): void
     {
-        // Aquí implementarías el procesamiento en background
-        // OCR, extracción de texto, generación de embeddings, etc.
-
-        // Por ahora, marcar como completado
         $document->update([
-            'processing_status' => 'completed',
-            'extracted_text' => 'Texto extraído simulado del documento: ' . $document->original_filename
+            'processing_status' => 'processing',
+            'processing_error' => null,
         ]);
+
+        ProcessAiDocumentJob::dispatch($document->id);
     }
 }

--- a/app/Jobs/ProcessAiDocumentJob.php
+++ b/app/Jobs/ProcessAiDocumentJob.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\AiContextEmbedding;
+use App\Models\AiDocument;
+use App\Models\GoogleToken;
+use App\Services\ChunkerService;
+use App\Services\EmbeddingService;
+use App\Services\ExtractorService;
+use App\Services\GoogleDriveService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use RuntimeException;
+use Throwable;
+
+class ProcessAiDocumentJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(private readonly int $documentId)
+    {
+    }
+
+    public function handle(
+        GoogleDriveService $driveService,
+        ExtractorService $extractorService,
+        ChunkerService $chunkerService,
+        EmbeddingService $embeddingService
+    ): void {
+        $document = AiDocument::find($this->documentId);
+
+        if (! $document) {
+            return;
+        }
+
+        $document->update([
+            'processing_status' => 'processing',
+            'processing_error' => null,
+        ]);
+
+        $tempFile = null;
+
+        try {
+            $token = $this->resolveAccessToken($document);
+            if (! $token) {
+                throw new RuntimeException('No hay credenciales válidas para acceder a Google Drive.');
+            }
+
+            $driveService->setAccessToken($token);
+            $fileContents = $driveService->downloadFileContent($document->drive_file_id);
+
+            if ($fileContents === null) {
+                throw new RuntimeException('No se pudo descargar el archivo desde Google Drive.');
+            }
+
+            $tempFile = $this->storeTemporaryFile($document, $fileContents);
+
+            $extracted = $extractorService->extract(
+                $tempFile['absolute_path'],
+                $document->mime_type ?? 'application/octet-stream',
+                $document->original_filename
+            );
+
+            $text = $extracted['text'] ?? '';
+            if (trim($text) === '') {
+                throw new RuntimeException('El documento no contiene texto utilizable.');
+            }
+
+            $chunkResult = $chunkerService->chunk($text);
+            $chunks = $chunkResult['chunks'] ?? [];
+            $normalizedText = $chunkResult['normalized_text'] ?? '';
+
+            if (empty($chunks)) {
+                throw new RuntimeException('No se pudieron generar fragmentos del documento.');
+            }
+
+            $embeddingModel = config('services.openai.embedding_model', 'text-embedding-3-small');
+            $embeddings = $embeddingService->embedChunks($chunks, 20, $embeddingModel);
+
+            if (empty($embeddings)) {
+                throw new RuntimeException('No se obtuvieron embeddings para los fragmentos generados.');
+            }
+
+            DB::transaction(function () use ($document, $chunks, $normalizedText, $embeddings, $extracted, $embeddingModel) {
+                AiContextEmbedding::where('content_type', 'document_text')
+                    ->where('content_id', (string) $document->id)
+                    ->where('username', $document->username)
+                    ->delete();
+
+                foreach ($chunks as $chunk) {
+                    $index = $chunk['index'];
+                    $vector = $embeddings[$index] ?? null;
+
+                    if (empty($vector)) {
+                        continue;
+                    }
+
+                    $metadata = array_merge(
+                        $extracted['metadata'] ?? [],
+                        $chunk['metadata'] ?? [],
+                        [
+                            'chunk_index' => $index,
+                            'tokens' => $chunk['tokens'] ?? null,
+                            'embedding_model' => $embeddingModel,
+                            'source_filename' => $document->original_filename,
+                        ]
+                    );
+
+                    AiContextEmbedding::create([
+                        'username' => $document->username,
+                        'content_type' => 'document_text',
+                        'content_id' => (string) $document->id,
+                        'content_snippet' => $chunk['normalized_text'],
+                        'embedding_vector' => $vector,
+                        'metadata' => $metadata,
+                    ]);
+                }
+
+                $document->update([
+                    'extracted_text' => $normalizedText,
+                    'ocr_metadata' => $extracted['metadata'] ?? [],
+                    'processing_status' => 'completed',
+                    'processing_error' => null,
+                ]);
+            });
+        } catch (Throwable $exception) {
+            $document->update([
+                'processing_status' => 'failed',
+                'processing_error' => $exception->getMessage(),
+            ]);
+
+            Log::error('Failed to process AI document', [
+                'document_id' => $document->id,
+                'error' => $exception->getMessage(),
+                'trace' => $exception->getTraceAsString(),
+            ]);
+
+            $this->fail($exception);
+        } finally {
+            if ($tempFile) {
+                $this->cleanupTemporaryFile($tempFile);
+            }
+        }
+    }
+
+    private function resolveAccessToken(AiDocument $document): ?array
+    {
+        if ($document->drive_type === 'organization') {
+            $organization = $document->user?->organization;
+            $token = $organization?->googleToken;
+
+            if ($token) {
+                $accessToken = $token->access_token;
+                if (is_array($accessToken)) {
+                    $accessToken = $accessToken['access_token'] ?? null;
+                }
+
+                if (! $accessToken) {
+                    return null;
+                }
+
+                return [
+                    'access_token' => $accessToken,
+                    'refresh_token' => $token->refresh_token,
+                ];
+            }
+        }
+
+        $token = GoogleToken::where('username', $document->username)->first();
+        if ($token && $token->hasValidAccessToken()) {
+            return $token->getTokenArray();
+        }
+
+        return null;
+    }
+
+    private function storeTemporaryFile(AiDocument $document, string $contents): array
+    {
+        $extension = strtolower(pathinfo($document->original_filename ?? '', PATHINFO_EXTENSION)) ?: 'tmp';
+        $directory = 'ai-documents/' . $document->id;
+        $filename = Str::uuid()->toString() . '.' . $extension;
+        $relativePath = $directory . '/' . $filename;
+
+        Storage::disk('local')->put($relativePath, $contents);
+
+        return [
+            'relative_path' => $relativePath,
+            'absolute_path' => Storage::disk('local')->path($relativePath),
+        ];
+    }
+
+    private function cleanupTemporaryFile(array $tempFile): void
+    {
+        $relativePath = $tempFile['relative_path'] ?? null;
+        if ($relativePath) {
+            Storage::disk('local')->delete($relativePath);
+            $directory = dirname($relativePath);
+            if ($directory && $directory !== '.') {
+                $files = Storage::disk('local')->files($directory);
+                $directories = Storage::disk('local')->directories($directory);
+                if (empty($files) && empty($directories)) {
+                    Storage::disk('local')->deleteDirectory($directory);
+                }
+            }
+        }
+    }
+}

--- a/app/Services/ChunkerService.php
+++ b/app/Services/ChunkerService.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Str;
+
+class ChunkerService
+{
+    /**
+     * Chunk normalized text into overlapping windows suitable for embeddings.
+     *
+     * @param  array{chunk_size?: int, chunk_overlap?: int}  $options
+     * @return array{normalized_text: string, chunks: array<int, array<string, mixed>>}
+     */
+    public function chunk(string $text, array $options = []): array
+    {
+        $normalized = $this->normalizeText($text);
+
+        $chunkSize = max(200, (int) ($options['chunk_size'] ?? 1500));
+        $overlap = (int) ($options['chunk_overlap'] ?? 200);
+        $overlap = max(0, min($overlap, $chunkSize - 1));
+
+        $chunks = [];
+        $length = mb_strlen($normalized);
+        $offset = 0;
+        $index = 0;
+
+        while ($offset < $length) {
+            $segment = mb_substr($normalized, $offset, $chunkSize);
+
+            if ($segment === '') {
+                break;
+            }
+
+            $segment = $this->balanceChunk($segment, $offset + $chunkSize < $length);
+            $segment = trim($segment);
+
+            if ($segment === '') {
+                $offset += max(1, $chunkSize - $overlap);
+                continue;
+            }
+
+            $actualLength = mb_strlen($segment);
+
+            $chunks[] = [
+                'index' => $index,
+                'normalized_text' => $segment,
+                'tokens' => $this->estimateTokens($segment),
+                'metadata' => [
+                    'start_offset' => $offset,
+                    'end_offset' => $offset + $actualLength,
+                    'length' => $actualLength,
+                ],
+            ];
+
+            $offset += max(1, $chunkSize - $overlap);
+            $index++;
+        }
+
+        return [
+            'normalized_text' => $normalized,
+            'chunks' => $chunks,
+        ];
+    }
+
+    /**
+     * Attempt to cut the chunk at a natural boundary when possible.
+     */
+    private function balanceChunk(string $segment, bool $hasMore): string
+    {
+        if (! $hasMore) {
+            return $segment;
+        }
+
+        $breakpoints = ["\n\n", "\n", '. '];
+        foreach ($breakpoints as $breakpoint) {
+            $position = mb_strrpos($segment, $breakpoint);
+            if ($position !== false && $position > mb_strlen($segment) * 0.5) {
+                return mb_substr($segment, 0, $position + mb_strlen($breakpoint));
+            }
+        }
+
+        return $segment;
+    }
+
+    private function normalizeText(string $text): string
+    {
+        return Str::of($text)
+            ->replace(["\r\n", "\r"], "\n")
+            ->replaceMatches('/[\x00-\x08\x0B\x0C\x0E-\x1F]/u', ' ')
+            ->replaceMatches('/[ \t\f\v]+/', ' ')
+            ->replaceMatches('/\n{3,}/', "\n\n")
+            ->trim()
+            ->toString();
+    }
+
+    private function estimateTokens(string $text): int
+    {
+        $words = preg_split('/\s+/u', trim($text));
+        $wordCount = is_array($words) ? count(array_filter($words)) : 0;
+        $charCount = mb_strlen($text);
+
+        // Approximate GPT tokens: average 4 characters per token.
+        $estimateFromChars = (int) ceil($charCount / 4);
+
+        return max(1, max($wordCount, $estimateFromChars));
+    }
+}

--- a/app/Services/EmbeddingService.php
+++ b/app/Services/EmbeddingService.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Arr;
+use OpenAI\Laravel\Facades\OpenAI;
+use RuntimeException;
+use Throwable;
+
+class EmbeddingService
+{
+    /**
+     * Generate embedding vectors for the provided chunks in batches.
+     *
+     * @param  array<int, array<string, mixed>>  $chunks
+     * @return array<int, array<int, float>>
+     */
+    public function embedChunks(array $chunks, int $batchSize = 10, ?string $model = null): array
+    {
+        if (empty($chunks)) {
+            return [];
+        }
+
+        $apiKey = config('services.openai.api_key');
+        if (! $apiKey) {
+            throw new RuntimeException('Falta la API key de OpenAI para generar embeddings.');
+        }
+
+        $modelName = $model ?? config('services.openai.embedding_model', 'text-embedding-3-small');
+        $client = OpenAI::client($apiKey);
+
+        $vectors = [];
+        $batches = array_chunk($chunks, max(1, $batchSize));
+
+        foreach ($batches as $batch) {
+            $inputs = [];
+            $indexMap = [];
+
+            foreach ($batch as $chunk) {
+                $text = $chunk['normalized_text'] ?? '';
+                if (! is_string($text) || trim($text) === '') {
+                    continue;
+                }
+
+                $inputs[] = $text;
+                $indexMap[] = $chunk['index'] ?? null;
+            }
+
+            if (empty($inputs)) {
+                continue;
+            }
+
+            try {
+                $response = $client->embeddings()->create([
+                    'model' => $modelName,
+                    'input' => $inputs,
+                ]);
+            } catch (Throwable $exception) {
+                throw new RuntimeException('Error al generar embeddings: ' . $exception->getMessage(), 0, $exception);
+            }
+
+            foreach ($response->data as $position => $data) {
+                $chunkIndex = $indexMap[$position] ?? $position;
+                $embedding = $data->embedding ?? [];
+
+                $vectors[$chunkIndex] = array_map(static fn ($value) => (float) $value, Arr::wrap($embedding));
+            }
+        }
+
+        ksort($vectors);
+
+        return $vectors;
+    }
+}

--- a/app/Services/ExtractorService.php
+++ b/app/Services/ExtractorService.php
@@ -1,0 +1,446 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use RuntimeException;
+use Symfony\Component\Process\Process;
+use ZipArchive;
+
+class ExtractorService
+{
+    /**
+     * Extracts normalized text content from a document located at the given path.
+     *
+     * @return array{ text: string, metadata: array }
+     */
+    public function extract(string $filePath, string $mimeType, ?string $filename = null): array
+    {
+        $extension = strtolower(pathinfo($filename ?? $filePath, PATHINFO_EXTENSION));
+
+        if ($this->isPdf($mimeType, $extension)) {
+            return $this->extractPdf($filePath);
+        }
+
+        if ($this->isWordDocument($mimeType, $extension)) {
+            return $this->extractWord($filePath, $extension);
+        }
+
+        if ($this->isSpreadsheet($mimeType, $extension)) {
+            return $this->extractSpreadsheet($filePath, $extension);
+        }
+
+        if ($this->isImage($mimeType, $extension)) {
+            return $this->extractImage($filePath);
+        }
+
+        return $this->extractPlainText($filePath);
+    }
+
+    private function isPdf(string $mimeType, string $extension): bool
+    {
+        return str_contains($mimeType, 'pdf') || $extension === 'pdf';
+    }
+
+    private function isWordDocument(string $mimeType, string $extension): bool
+    {
+        return str_contains($mimeType, 'word') || in_array($extension, ['doc', 'docx']);
+    }
+
+    private function isSpreadsheet(string $mimeType, string $extension): bool
+    {
+        return str_contains($mimeType, 'sheet') || str_contains($mimeType, 'excel')
+            || in_array($extension, ['xls', 'xlsx', 'csv']);
+    }
+
+    private function isImage(string $mimeType, string $extension): bool
+    {
+        return str_starts_with($mimeType, 'image/')
+            || in_array($extension, ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'tif', 'tiff', 'webp']);
+    }
+
+    private function extractPlainText(string $filePath): array
+    {
+        $contents = File::get($filePath);
+        $text = $this->normalizeText($contents ?? '');
+
+        return [
+            'text' => $text,
+            'metadata' => [
+                'detected_type' => 'text/plain',
+                'original_bytes' => File::size($filePath),
+            ],
+        ];
+    }
+
+    private function extractPdf(string $filePath): array
+    {
+        // Prefer native PHP libraries if they are installed.
+        if (class_exists('Smalot\\PdfParser\\Parser')) {
+            try {
+                $parser = new \Smalot\PdfParser\Parser();
+                $pdf = $parser->parseFile($filePath);
+                $text = $this->normalizeText($pdf->getText());
+
+                return [
+                    'text' => $text,
+                    'metadata' => [
+                        'detected_type' => 'application/pdf',
+                        'pages' => count($pdf->getPages()),
+                        'engine' => 'smalot/pdfparser',
+                    ],
+                ];
+            } catch (\Throwable $exception) {
+                // Fall back to CLI strategy below.
+            }
+        }
+
+        $binary = $this->resolveBinary('pdftotext');
+        if ($binary) {
+            $outputFile = $filePath . '.txt';
+            $process = new Process([$binary, '-layout', $filePath, $outputFile]);
+            $process->setTimeout(60);
+            $process->run();
+
+            if (! $process->isSuccessful()) {
+                throw new RuntimeException('No se pudo extraer texto del PDF: ' . $process->getErrorOutput());
+            }
+
+            $text = File::exists($outputFile) ? File::get($outputFile) : '';
+            if ($text === false) {
+                $text = '';
+            }
+
+            if ($outputFile && File::exists($outputFile)) {
+                File::delete($outputFile);
+            }
+
+            return [
+                'text' => $this->normalizeText($text),
+                'metadata' => [
+                    'detected_type' => 'application/pdf',
+                    'engine' => 'pdftotext-cli',
+                ],
+            ];
+        }
+
+        throw new RuntimeException('No se encontró ningún motor para extraer texto de PDF.');
+    }
+
+    private function extractWord(string $filePath, string $extension): array
+    {
+        if (class_exists('PhpOffice\\PhpWord\\IOFactory')) {
+            try {
+                $phpWord = \PhpOffice\PhpWord\IOFactory::load($filePath);
+                $sections = $phpWord->getSections();
+                $lines = [];
+
+                foreach ($sections as $section) {
+                    foreach ($section->getElements() as $element) {
+                        if (method_exists($element, 'getText')) {
+                            $lines[] = $element->getText();
+                        }
+                    }
+                }
+
+                return [
+                    'text' => $this->normalizeText(implode("\n", $lines)),
+                    'metadata' => [
+                        'detected_type' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                        'engine' => 'phpoffice/phpword',
+                    ],
+                ];
+            } catch (\Throwable $exception) {
+                // Fall back to manual extraction below.
+            }
+        }
+
+        if ($extension === 'docx') {
+            return $this->extractDocx($filePath);
+        }
+
+        // Legacy .doc files are binary; we attempt a best-effort extraction.
+        $contents = File::get($filePath);
+        $text = $this->normalizeText($contents ?? '');
+
+        return [
+            'text' => $text,
+            'metadata' => [
+                'detected_type' => 'application/msword',
+                'engine' => 'fallback-binary-cleanup',
+            ],
+        ];
+    }
+
+    private function extractDocx(string $filePath): array
+    {
+        $zip = new ZipArchive();
+        if ($zip->open($filePath) !== true) {
+            throw new RuntimeException('No se pudo abrir el archivo DOCX.');
+        }
+
+        $documentXml = $zip->getFromName('word/document.xml');
+        $zip->close();
+
+        if ($documentXml === false) {
+            throw new RuntimeException('El archivo DOCX no contiene document.xml.');
+        }
+
+        $xml = simplexml_load_string($documentXml);
+        if (! $xml) {
+            throw new RuntimeException('No se pudo interpretar el contenido del DOCX.');
+        }
+
+        $xml->registerXPathNamespace('w', 'http://schemas.openxmlformats.org/wordprocessingml/2006/main');
+        $paragraphs = $xml->xpath('//w:p');
+        $lines = [];
+
+        foreach ($paragraphs as $paragraph) {
+            $texts = [];
+            foreach ($paragraph->xpath('.//w:t') as $node) {
+                $texts[] = (string) $node;
+            }
+            if (! empty($texts)) {
+                $lines[] = implode('', $texts);
+            }
+        }
+
+        return [
+            'text' => $this->normalizeText(implode("\n", $lines)),
+            'metadata' => [
+                'detected_type' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                'engine' => 'zip-xml',
+            ],
+        ];
+    }
+
+    private function extractSpreadsheet(string $filePath, string $extension): array
+    {
+        if (class_exists('PhpOffice\\PhpSpreadsheet\\IOFactory')) {
+            try {
+                $spreadsheet = \PhpOffice\PhpSpreadsheet\IOFactory::load($filePath);
+                $sheets = [];
+
+                foreach ($spreadsheet->getAllSheets() as $sheet) {
+                    $rows = [];
+                    foreach ($sheet->getRowIterator() as $row) {
+                        $cellValues = [];
+                        foreach ($row->getCellIterator() as $cell) {
+                            $cellValues[] = trim((string) $cell->getCalculatedValue());
+                        }
+                        $rows[] = trim(implode("\t", array_filter($cellValues, fn ($value) => $value !== '')));
+                    }
+                    $rows = array_filter($rows, fn ($rowText) => $rowText !== '');
+                    $sheets[] = [
+                        'name' => $sheet->getTitle(),
+                        'rows' => $rows,
+                    ];
+                }
+
+                $lines = [];
+                foreach ($sheets as $sheet) {
+                    $lines[] = "# Hoja: " . $sheet['name'];
+                    $lines = array_merge($lines, $sheet['rows']);
+                }
+
+                return [
+                    'text' => $this->normalizeText(implode("\n", $lines)),
+                    'metadata' => [
+                        'detected_type' => 'spreadsheet',
+                        'engine' => 'phpoffice/phpspreadsheet',
+                        'sheet_count' => count($sheets),
+                    ],
+                ];
+            } catch (\Throwable $exception) {
+                // Fallback manual extraction below.
+            }
+        }
+
+        if ($extension === 'csv') {
+            $text = $this->normalizeText(File::get($filePath) ?? '');
+            return [
+                'text' => $text,
+                'metadata' => [
+                    'detected_type' => 'text/csv',
+                    'engine' => 'csv-plain',
+                ],
+            ];
+        }
+
+        return $this->extractXlsxManually($filePath);
+    }
+
+    private function extractXlsxManually(string $filePath): array
+    {
+        $zip = new ZipArchive();
+        if ($zip->open($filePath) !== true) {
+            throw new RuntimeException('No se pudo abrir el archivo XLSX.');
+        }
+
+        $sharedStrings = [];
+        $shared = $zip->getFromName('xl/sharedStrings.xml');
+        if ($shared !== false) {
+            $xml = simplexml_load_string($shared);
+            if ($xml) {
+                $xml->registerXPathNamespace('s', 'http://schemas.openxmlformats.org/spreadsheetml/2006/main');
+                foreach ($xml->xpath('//s:si') as $stringItem) {
+                    $pieces = [];
+                    foreach ($stringItem->xpath('.//s:t') as $node) {
+                        $pieces[] = (string) $node;
+                    }
+                    $sharedStrings[] = implode('', $pieces);
+                }
+            }
+        }
+
+        $sheetSummaries = [];
+        $lines = [];
+
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $stat = $zip->statIndex($i);
+            $name = $stat['name'];
+            if (! str_starts_with($name, 'xl/worksheets/sheet')) {
+                continue;
+            }
+
+            $sheetContent = $zip->getFromIndex($i);
+            if ($sheetContent === false) {
+                continue;
+            }
+
+            $xml = simplexml_load_string($sheetContent);
+            if (! $xml) {
+                continue;
+            }
+
+            $xml->registerXPathNamespace('s', 'http://schemas.openxmlformats.org/spreadsheetml/2006/main');
+            $rows = [];
+            foreach ($xml->sheetData->row as $row) {
+                $values = [];
+                foreach ($row->c as $cell) {
+                    $values[] = $this->resolveSpreadsheetValue($cell, $sharedStrings);
+                }
+                $rows[] = trim(implode("\t", array_filter($values, fn ($value) => $value !== '')));
+            }
+
+            $rows = array_filter($rows, fn ($rowText) => $rowText !== '');
+            $sheetSummaries[] = [
+                'name' => $name,
+                'rows' => count($rows),
+            ];
+            if (! empty($rows)) {
+                $lines[] = '# Hoja: ' . $name;
+                $lines = array_merge($lines, $rows);
+            }
+        }
+
+        $zip->close();
+
+        return [
+            'text' => $this->normalizeText(implode("\n", $lines)),
+            'metadata' => [
+                'detected_type' => 'spreadsheet',
+                'engine' => 'zip-xml',
+                'sheets' => $sheetSummaries,
+            ],
+        ];
+    }
+
+    private function resolveSpreadsheetValue(\SimpleXMLElement $cell, array $sharedStrings): string
+    {
+        $type = (string) ($cell['t'] ?? '');
+        if ($type === 's') {
+            $index = (int) ($cell->v ?? 0);
+            return $sharedStrings[$index] ?? '';
+        }
+
+        if ($type === 'inlineStr') {
+            return trim((string) ($cell->is->t ?? ''));
+        }
+
+        if ($type === 'b') {
+            return ((string) $cell->v) === '1' ? 'TRUE' : 'FALSE';
+        }
+
+        return trim((string) ($cell->v ?? ''));
+    }
+
+    private function extractImage(string $filePath): array
+    {
+        if (class_exists('thiagoalessio\\TesseractOCR\\TesseractOCR')) {
+            try {
+                $ocr = new \thiagoalessio\TesseractOCR\TesseractOCR($filePath);
+                $ocr->lang('spa', 'eng');
+                $text = $ocr->run();
+
+                return [
+                    'text' => $this->normalizeText($text),
+                    'metadata' => [
+                        'detected_type' => 'image/ocr',
+                        'engine' => 'tesseract-php',
+                    ],
+                ];
+            } catch (\Throwable $exception) {
+                // Fallback to CLI below.
+            }
+        }
+
+        $binary = $this->resolveBinary('tesseract');
+        if (! $binary) {
+            throw new RuntimeException('No se encontró un motor OCR disponible para imágenes.');
+        }
+
+        $tempOutput = $filePath . '_ocr';
+        $process = new Process([$binary, $filePath, $tempOutput, '-l', 'spa+eng']);
+        $process->setTimeout(60);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            throw new RuntimeException('No se pudo ejecutar OCR: ' . $process->getErrorOutput());
+        }
+
+        $textFile = $tempOutput . '.txt';
+        $text = File::exists($textFile) ? File::get($textFile) : '';
+
+        if (File::exists($textFile)) {
+            File::delete($textFile);
+        }
+
+        return [
+            'text' => $this->normalizeText($text),
+            'metadata' => [
+                'detected_type' => 'image/ocr',
+                'engine' => 'tesseract-cli',
+            ],
+        ];
+    }
+
+    private function normalizeText(string $text): string
+    {
+        $text = Str::of($text)
+            ->replace(["\r\n", "\r"], "\n")
+            ->replaceMatches('/[\x00-\x08\x0B\x0C\x0E-\x1F]/u', ' ')
+            ->replaceMatches('/[ \t\f\v]+/', ' ')
+            ->replaceMatches('/\n{3,}/', "\n\n")
+            ->trim()
+            ->toString();
+
+        return $text;
+    }
+
+    private function resolveBinary(string $binary): ?string
+    {
+        $process = Process::fromShellCommandline('command -v ' . escapeshellarg($binary));
+        $process->setTimeout(5);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            return null;
+        }
+
+        $path = trim($process->getOutput());
+
+        return $path !== '' ? $path : null;
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated extractor, chunker, and embedding services to support PDF, Office, image OCR, and text ingestion
- introduce a queued ProcessAiDocumentJob to download Drive files, extract text, chunk content, generate embeddings in batches, and persist AiContextEmbedding rows
- update AiAssistantController to mark documents as processing and dispatch the background job instead of stubbing the pipeline

## Testing
- php -l app/Services/ExtractorService.php
- php -l app/Services/ChunkerService.php
- php -l app/Services/EmbeddingService.php
- php -l app/Jobs/ProcessAiDocumentJob.php
- php -l app/Http/Controllers/AiAssistantController.php

------
https://chatgpt.com/codex/tasks/task_e_68c9a3acc2a88323ad1be67f08b54486