### PR TITLE
Protect organization API routes with web auth

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -86,7 +86,7 @@ Route::middleware(['web', 'auth'])->group(function () {
 Route::get('/organization-activities', [OrganizationActivityController::class, 'index'])
     ->middleware(['web', 'auth']);
 
-
+Route::middleware(['web', 'auth'])->group(function () {
     // Rutas de Organizaciones
     Route::get('/organizations', [OrganizationController::class, 'index'])->name('api.organizations.index');
     Route::post('/organizations', [OrganizationController::class, 'store'])->name('api.organizations.store');
@@ -97,14 +97,13 @@ Route::get('/organization-activities', [OrganizationActivityController::class, '
     Route::delete('/organizations/{organization}', [OrganizationController::class, 'destroy'])->name('api.organizations.destroy');
 
     // Rutas de Google Drive para organizaciones (control de permisos en el controlador)
-    Route::middleware(['web', 'auth'])->group(function () {
-        Route::post('/organizations/{organization}/drive/root-folder', [OrganizationDriveController::class, 'createRootFolder'])->name('api.organizations.drive.root-folder');
-        Route::post('/organizations/{organization}/drive/subfolders', [OrganizationDriveController::class, 'createSubfolder'])->name('api.organizations.drive.subfolders.store');
-        Route::get('/organizations/{organization}/drive/subfolders', [OrganizationDriveController::class, 'listSubfolders'])->name('api.organizations.drive.subfolders.index');
-        Route::get('/organizations/{organization}/drive/status', [OrganizationDriveController::class, 'status'])->name('api.organizations.drive.status');
-        Route::patch('/organizations/{organization}/drive/subfolders/{subfolder}', [OrganizationDriveController::class, 'renameSubfolder'])->name('api.organizations.drive.subfolders.update');
-        Route::delete('/organizations/{organization}/drive/subfolders/{subfolder}', [OrganizationDriveController::class, 'deleteSubfolder'])->name('api.organizations.drive.subfolders.destroy');
-    });
+    Route::post('/organizations/{organization}/drive/root-folder', [OrganizationDriveController::class, 'createRootFolder'])->name('api.organizations.drive.root-folder');
+    Route::post('/organizations/{organization}/drive/subfolders', [OrganizationDriveController::class, 'createSubfolder'])->name('api.organizations.drive.subfolders.store');
+    Route::get('/organizations/{organization}/drive/subfolders', [OrganizationDriveController::class, 'listSubfolders'])->name('api.organizations.drive.subfolders.index');
+    Route::get('/organizations/{organization}/drive/status', [OrganizationDriveController::class, 'status'])->name('api.organizations.drive.status');
+    Route::patch('/organizations/{organization}/drive/subfolders/{subfolder}', [OrganizationDriveController::class, 'renameSubfolder'])->name('api.organizations.drive.subfolders.update');
+    Route::delete('/organizations/{organization}/drive/subfolders/{subfolder}', [OrganizationDriveController::class, 'deleteSubfolder'])->name('api.organizations.drive.subfolders.destroy');
+});
 
     // Rutas de Usuarios
     Route::post('/users/check-email', [UserController::class, 'checkEmail'])->name('api.users.check-email');


### PR DESCRIPTION
## Summary
- wrap all organization API endpoints in a shared `Route::middleware(['web', 'auth'])` group so SPA requests keep the authenticated session
- remove the redundant nested middleware declaration from the organization Drive routes

## Testing
- ⚠️ not run (vendor dependencies missing; manual SPA validation not possible in container)


------
https://chatgpt.com/codex/tasks/task_e_68c9c2fc03ec8323adb8ec692eddeda5