### PR TITLE
Actualizar frontends de reuniones para payload legacy

### DIFF
--- a/public/js/ai-assistant.js
+++ b/public/js/ai-assistant.js
@@ -552,13 +552,18 @@ function renderMeetings(meetings) {
         return;
     }
 
-    grid.innerHTML = meetings.map(meeting => `
+    grid.innerHTML = meetings.map(meeting => {
+        const title = meeting.meeting_name || 'Reunión sin título';
+        const createdAt = formatDate(meeting.created_at);
+        const duration = meeting.duration ? String(meeting.duration) : 'Duración no disponible';
+
+        return `
         <div class="meeting-card">
             <div class="meeting-card-header">
                 <div class="meeting-card-title" onclick="openMeetingDetails(${meeting.id})">
-                    <h4>${escapeHtml(meeting.meeting_name || meeting.title)}</h4>
+                    <h4>${escapeHtml(title)}</h4>
                     <div class="meeting-card-meta">
-                        ${formatDate(meeting.created_at)} • ${meeting.duration || 'Duración no disponible'}
+                        ${escapeHtml(createdAt)} • ${escapeHtml(duration)}
                     </div>
                 </div>
             </div>
@@ -570,7 +575,8 @@ function renderMeetings(meetings) {
                 </button>
             </div>
         </div>
-    `).join('');
+    `;
+    }).join('');
 }
 
 /**
@@ -583,7 +589,7 @@ async function openMeetingDetails(meetingId) {
     // Encontrar la reunión en la lista
     const meeting = allMeetings.find(m => m.id === meetingId);
     if (meeting) {
-        document.getElementById('meetingDetailsTitle').textContent = meeting.meeting_name || meeting.title;
+        document.getElementById('meetingDetailsTitle').textContent = meeting.meeting_name || 'Reunión sin título';
     }
 
     // Mostrar estado de carga en todas las pestañas
@@ -769,7 +775,7 @@ function addMeetingToContext(meetingId) {
     loadedContextItems.push({
         type: 'meeting',
         id: meetingId,
-        title: meeting.meeting_name || meeting.title,
+        title: meeting.meeting_name || 'Reunión sin título',
         data: meeting
     });
 
@@ -857,7 +863,7 @@ function filterContextItems(searchTerm) {
         renderContainers(filtered);
     } else if (currentContextType === 'meetings') {
         const filtered = allMeetings.filter(meeting =>
-            (meeting.meeting_name || meeting.title).toLowerCase().includes(term)
+            (meeting.meeting_name || '').toLowerCase().includes(term)
         );
         renderMeetings(filtered);
     }
@@ -1797,7 +1803,15 @@ function showNotification(message, type = 'info') {
  * Formatear fecha
  */
 function formatDate(dateString) {
+    if (!dateString) {
+        return 'Fecha no disponible';
+    }
+
     const date = new Date(dateString);
+    if (Number.isNaN(date.getTime())) {
+        return dateString;
+    }
+
     return date.toLocaleDateString('es-ES', {
         year: 'numeric',
         month: 'short',

--- a/resources/js/reuniones_v2.js
+++ b/resources/js/reuniones_v2.js
@@ -173,10 +173,7 @@ async function loadMyMeetings() {
         const data = await response.json();
 
         if (data.success) {
-            const meetings = [
-                ...(Array.isArray(data.meetings) ? data.meetings : []),
-                ...(Array.isArray(data.legacy_meetings) ? data.legacy_meetings : []),
-            ];
+            const meetings = Array.isArray(data.meetings) ? data.meetings : [];
             currentMeetings = meetings;
             renderMeetings(currentMeetings, '#my-meetings', 'No tienes reuniones');
         } else {
@@ -2438,13 +2435,11 @@ async function openMeetingModal(meetingId, sharedMeetingId = null) {
                 meeting.transcription = meeting.segments.map(s => s.text).join(' ');
             }
 
-            if (meeting.is_legacy) {
-                updateLoadingStep(4); // Omitir pasos de descarga/desencriptado
-            } else {
-                updateLoadingStep(2); // Paso 2: Descifrando archivo
-                updateLoadingStep(3); // Paso 3: Descargando audio
-                updateLoadingStep(4); // Paso 4: Procesando contenido
-            }
+            updateLoadingStep(2); // Paso 2
+            await new Promise(resolve => setTimeout(resolve, 150));
+            updateLoadingStep(3); // Paso 3
+            await new Promise(resolve => setTimeout(resolve, 150));
+            updateLoadingStep(4); // Paso 4
 
             // Esperar un poco para mostrar el progreso completo
             await new Promise(resolve => setTimeout(resolve, 500));
@@ -3259,19 +3254,19 @@ function showModalLoadingState() {
                         <div class="loading-steps">
                             <div class="loading-step active" id="step-1">
                                 <div class="step-icon">📥</div>
-                                <span>Descargando transcripción</span>
+                                <span>Recuperando datos</span>
                             </div>
                             <div class="loading-step" id="step-2">
-                                <div class="step-icon">🔓</div>
-                                <span>Descifrando archivo</span>
+                                <div class="step-icon">📝</div>
+                                <span>Preparando transcripción</span>
                             </div>
                             <div class="loading-step" id="step-3">
                                 <div class="step-icon">🎵</div>
-                                <span>Descargando audio</span>
+                                <span>Cargando audio</span>
                             </div>
                             <div class="loading-step" id="step-4">
                                 <div class="step-icon">⚡</div>
-                                <span>Procesando contenido</span>
+                                <span>Finalizando análisis</span>
                             </div>
                         </div>
                     </div>

--- a/resources/js/tasks/calendar.js
+++ b/resources/js/tasks/calendar.js
@@ -405,12 +405,7 @@ document.addEventListener('DOMContentLoaded', () => {
         };
       }
 
-      let meetingFolderId = null;
-      try{
-        const mRes = await fetch(`/api/meetings/${t.meeting_id}`);
-        const mData = await mRes.json();
-        meetingFolderId = mData.meeting?.recordings_folder_id || null;
-      }catch(_){}
+      const meetingFolderId = null;
 
       await loadFolders(meetingFolderId); await loadFiles();
       async function loadFolders(rootId){ const sel = modal.querySelector('#drive-folder'); const url = rootId ? `/api/drive/folders?parents=${encodeURIComponent(rootId)}` : '/api/drive/folders'; const res = await fetch(url); const data = await res.json(); sel.innerHTML=''; (data.folders||[]).forEach(f=>{ const opt=document.createElement('option'); opt.value=f.id; opt.textContent=f.name; sel.appendChild(opt); }); }


### PR DESCRIPTION
## Summary
- simplificar la carga de reuniones en `reuniones_v2.js` y adaptar el modal para mostrar únicamente pasos compatibles con datos legacy
- actualizar el asistente IA para consumir el payload legacy, sanitizando los títulos, fechas y búsquedas de reuniones
- reescribir la vista de detalle de reuniones en organizaciones y el calendario de tareas para dejar de depender de campos modernos como `recordings_folder_id`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9ca4d29088323954ae5c01057d13b