### PR TITLE
Align meeting share migrations with legacy schema

### DIFF
--- a/database/migrations/2025_07_15_010317_create_meeting_shares_table.php
+++ b/database/migrations/2025_07_15_010317_create_meeting_shares_table.php
@@ -9,7 +9,8 @@ return new class extends Migration
     public function up()
     {
         Schema::create('meeting_shares', function (Blueprint $table) {
-            $table->unsignedInteger('meeting_id');
+            // Permite compartir reuniones legacy (transcriptions_laravel) o genéricas
+            $table->string('meeting_id', 191);
             $table->string('from_username', 255);
             $table->string('to_username', 255);
             $table->timestamp('created_at')->useCurrent();

--- a/database/migrations/2025_07_15_010552_create_meetings_table.php
+++ b/database/migrations/2025_07_15_010552_create_meetings_table.php
@@ -8,22 +8,13 @@ return new class extends Migration
 {
     public function up()
     {
-        Schema::create('meetings', function (Blueprint $table) {
-            $table->increments('id');
-            $table->string('title', 255);
-            $table->dateTime('date');
-            $table->string('duration', 50)->nullable();
-            $table->integer('participants')->default(0);
-            $table->text('summary')->nullable();
-            $table->string('recordings_folder_id', 255)->nullable();
-            $table->timestamp('created_at')->useCurrent();
-            $table->timestamp('updated_at')->useCurrent()->useCurrentOnUpdate();
-            $table->string('username', 255)->nullable();
-            $table->json('speaker_map')->nullable();
-        });
+        // El esquema legacy utiliza transcriptions_laravel como fuente de reuniones.
+        // Dejamos esta migración vacía para evitar crear una tabla "meetings" moderna
+        // que colisione con la estructura existente.
     }
+
     public function down()
     {
-        Schema::dropIfExists('meetings');
+        // Sin acciones: no se crea ni elimina la tabla legacy.
     }
 };

--- a/database/migrations/2025_09_09_162841_create_shared_meetings_table.php
+++ b/database/migrations/2025_09_09_162841_create_shared_meetings_table.php
@@ -15,7 +15,9 @@ return new class extends Migration
         if (!Schema::hasTable('shared_meetings')) {
             Schema::create('shared_meetings', function (Blueprint $table) {
                 $table->id();
-                $table->unsignedInteger('meeting_id'); // coincide con meetings.id (increments)
+                // meeting_id puede apuntar a registros legacy (transcriptions_laravel)
+                // o a otro identificador genérico, por eso lo almacenamos como string.
+                $table->string('meeting_id', 191);
                 // Users.id es UUID, definir columnas como uuid
                 $table->uuid('shared_by'); // Usuario que comparte
                 $table->uuid('shared_with'); // Usuario receptor
@@ -26,7 +28,6 @@ return new class extends Migration
                 $table->timestamps();
 
                 // FKs
-                $table->foreign('meeting_id')->references('id')->on('meetings')->onDelete('cascade');
                 $table->foreign('shared_by')->references('id')->on('users')->onDelete('cascade');
                 $table->foreign('shared_with')->references('id')->on('users')->onDelete('cascade');
 


### PR DESCRIPTION
## Summary
- deactivate the meetings table migration to avoid creating a modern meetings schema
- change shared_meetings.meeting_id to a string identifier and drop the meetings foreign key so legacy IDs are supported
- update meeting_shares to store meeting identifiers as strings for legacy compatibility

## Testing
- php artisan test *(fails: missing Composer dependencies due to GitHub authentication requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68c9cd861c1c832396a430206509427e