### PR TITLE
Ensure fetch interceptor sends credentials cross-origin

### DIFF
--- a/resources/js/utils/auth-interceptors.js
+++ b/resources/js/utils/auth-interceptors.js
@@ -46,9 +46,11 @@
   const opts = { ...init };
   const method = (opts.method || 'GET').toUpperCase();
 
-  // Ensure cookies are sent for same-origin requests so sessions work
+  // Ensure cookies are sent for session-authenticated APIs. On cross-origin
+  // calls we still include credentials so that applications running on
+  // whitelisted hosts (e.g. staging/admin portals) maintain the session.
   if (!opts.credentials) {
-    opts.credentials = isSameOrigin ? 'same-origin' : (opts.credentials || 'omit');
+    opts.credentials = isSameOrigin ? 'same-origin' : 'include';
   }
 
   // Normalize headers to a plain object


### PR DESCRIPTION
## Summary
- ensure the fetch interceptor defaults to including credentials on cross-origin requests so Laravel session cookies are sent
- document the reason for the new default to cover cross-origin hosts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9e2c311288323bda81d4905036523