### PR TITLE
Remove hardcoded same-origin credentials from organization fetch

### DIFF
--- a/resources/js/organization.js
+++ b/resources/js/organization.js
@@ -556,7 +556,6 @@ Alpine.data('organizationPage', (initialOrganizations = []) => ({
         const attempt = async (url) => {
             return fetch(url, {
                 method: 'POST',
-                credentials: 'same-origin',
                 headers: {
                     'Content-Type': 'application/json',
                     'Accept': 'application/json',


### PR DESCRIPTION
## Summary
- remove the hardcoded `credentials: 'same-origin'` option from the organization creation fetch helper so the global interceptor can manage credentials per request

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9fc78dc38832384d33d2eda7e6d2e