### PR TITLE
Convert uploaded audio to MP3 before transcription

### DIFF
--- a/app/Services/AudioConversionService.php
+++ b/app/Services/AudioConversionService.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+use Symfony\Component\Process\Process;
+
+class AudioConversionService
+{
+    /**
+     * Convert the provided audio file into MP3 format using ffmpeg.
+     *
+     * @param  string      $filePath
+     * @param  string|null $mimeType
+     * @param  string|null $originalExtension
+     * @return array{path:string,mime_type:string,was_converted:bool}
+     */
+    public function convertToMp3(string $filePath, ?string $mimeType = null, ?string $originalExtension = null): array
+    {
+        $detectedExtension = strtolower($originalExtension ?? pathinfo($filePath, PATHINFO_EXTENSION));
+        $detectedMime      = $mimeType ?? (is_readable($filePath) ? @mime_content_type($filePath) : null);
+
+        $isAlreadyMp3 = ($detectedMime && str_contains($detectedMime, 'mpeg')) || $detectedExtension === 'mp3';
+
+        if ($isAlreadyMp3) {
+            Log::info('Audio already in MP3 format, skipping conversion', [
+                'mime_type' => $detectedMime,
+                'extension' => $detectedExtension,
+            ]);
+
+            return [
+                'path'          => $filePath,
+                'mime_type'     => 'audio/mpeg',
+                'was_converted' => false,
+            ];
+        }
+
+        $tempPath = tempnam(sys_get_temp_dir(), 'converted_audio_');
+        if ($tempPath === false) {
+            throw new RuntimeException('Unable to create temporary file for MP3 conversion');
+        }
+        $targetPath = $tempPath . '.mp3';
+
+        $command = [
+            'ffmpeg',
+            '-y',
+            '-i',
+            $filePath,
+            '-vn',
+            '-acodec',
+            'libmp3lame',
+            '-f',
+            'mp3',
+            $targetPath,
+        ];
+
+        $process = new Process($command);
+        $process->setTimeout(3600);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            @unlink($targetPath);
+            throw new RuntimeException('FFmpeg conversion failed: ' . $process->getErrorOutput());
+        }
+
+        Log::info('Audio converted to MP3 using ffmpeg', [
+            'original_mime_type' => $detectedMime,
+            'original_extension' => $detectedExtension,
+            'target_path'        => $targetPath,
+        ]);
+
+        return [
+            'path'          => $targetPath,
+            'mime_type'     => 'audio/mpeg',
+            'was_converted' => true,
+        ];
+    }
+}

--- a/tests/Feature/TranscriptionControllerTest.php
+++ b/tests/Feature/TranscriptionControllerTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\AudioConversionService;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class TranscriptionControllerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('services.assemblyai.api_key', 'test-key');
+    }
+
+    public function test_wav_audio_is_converted_to_mp3_before_upload(): void
+    {
+        $fakeService = $this->createFakeConversionService();
+
+        $this->app->instance(AudioConversionService::class, $fakeService);
+
+        Http::fake([
+            'https://api.assemblyai.com/v2/upload' => Http::response(['upload_url' => 'https://example.com/uploaded'], 200),
+            'https://api.assemblyai.com/v2/transcript' => Http::response(['id' => 'transcript-id'], 200),
+        ]);
+
+        $wavFile = UploadedFile::fake()->createWithContent('sample.wav', 'wav audio', 'audio/wav');
+
+        $response = $this->postJson('/transcription', [
+            'audio' => $wavFile,
+            'language' => 'es',
+        ]);
+
+        $response->assertOk()->assertJson(['id' => 'transcript-id']);
+
+        $this->assertCount(1, $fakeService->calls);
+        $this->assertSame('audio/wav', $fakeService->calls[0]['mime_type']);
+        $this->assertTrue($fakeService->calls[0]['was_converted']);
+
+        Http::assertSentCount(2);
+        Http::assertSent(function ($request) use ($fakeService) {
+            if ($request->url() !== 'https://api.assemblyai.com/v2/upload') {
+                return true;
+            }
+
+            $expectedBody = $fakeService->calls[0]['content'];
+            return $request->body() === $expectedBody;
+        });
+
+        $fakeService->cleanup();
+    }
+
+    public function test_ogg_audio_is_converted_to_mp3_before_upload(): void
+    {
+        $fakeService = $this->createFakeConversionService();
+
+        $this->app->instance(AudioConversionService::class, $fakeService);
+
+        Http::fake([
+            'https://api.assemblyai.com/v2/upload' => Http::response(['upload_url' => 'https://example.com/uploaded'], 200),
+            'https://api.assemblyai.com/v2/transcript' => Http::response(['id' => 'transcript-id'], 200),
+        ]);
+
+        $oggFile = UploadedFile::fake()->createWithContent('sample.ogg', 'ogg audio', 'audio/ogg');
+
+        $response = $this->postJson('/transcription', [
+            'audio' => $oggFile,
+            'language' => 'es',
+        ]);
+
+        $response->assertOk()->assertJson(['id' => 'transcript-id']);
+
+        $this->assertCount(1, $fakeService->calls);
+        $this->assertSame('audio/ogg', $fakeService->calls[0]['mime_type']);
+        $this->assertTrue($fakeService->calls[0]['was_converted']);
+
+        Http::assertSentCount(2);
+        Http::assertSent(function ($request) use ($fakeService) {
+            if ($request->url() !== 'https://api.assemblyai.com/v2/upload') {
+                return true;
+            }
+
+            $expectedBody = $fakeService->calls[0]['content'];
+            return $request->body() === $expectedBody;
+        });
+
+        $fakeService->cleanup();
+    }
+
+    private function createFakeConversionService(): object
+    {
+        return new class extends AudioConversionService {
+            public array $calls = [];
+            private array $generated = [];
+
+            public function convertToMp3(string $filePath, ?string $mimeType = null, ?string $originalExtension = null): array
+            {
+                $content = 'converted-mp3-from-' . ($originalExtension ?? 'unknown');
+                $tempPath = tempnam(sys_get_temp_dir(), 'fake_mp3_');
+                file_put_contents($tempPath, $content);
+                $this->generated[] = $tempPath;
+
+                $this->calls[] = [
+                    'file_path' => $filePath,
+                    'mime_type' => $mimeType,
+                    'extension' => $originalExtension,
+                    'was_converted' => true,
+                    'content' => $content,
+                    'returned_path' => $tempPath,
+                ];
+
+                return [
+                    'path' => $tempPath,
+                    'mime_type' => 'audio/mpeg',
+                    'was_converted' => true,
+                ];
+            }
+
+            public function cleanup(): void
+            {
+                foreach ($this->generated as $path) {
+                    if (is_string($path) && file_exists($path)) {
+                        @unlink($path);
+                    }
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- allow uploading WAV, OGG, AAC, FLAC, WebM and related audio files while logging the expanded list of accepted formats
- introduce an AudioConversionService that uses ffmpeg to convert any accepted input to MP3 prior to contacting AssemblyAI and ensure failures use the converted asset
- add feature coverage to confirm WAV and OGG uploads trigger MP3 conversion before the AssemblyAI request is sent

## Testing
- php artisan test --filter=TranscriptionControllerTest *(blocked: composer install requires a GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb15cc2a5c8323b2b0326b8dc392c9