### PR TITLE
Ajustar carga de archivos a carpeta Documentos

### DIFF
--- a/database/factories/TaskLaravelFactory.php
+++ b/database/factories/TaskLaravelFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\TaskLaravel;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<TaskLaravel>
+ */
+class TaskLaravelFactory extends Factory
+{
+    protected $model = TaskLaravel::class;
+
+    public function definition(): array
+    {
+        return [
+            'username' => fake()->userName(),
+            'meeting_id' => null,
+            'tarea' => fake()->sentence(),
+            'prioridad' => fake()->randomElement(['alta', 'media', 'baja']),
+            'fecha_inicio' => now()->startOfDay(),
+            'fecha_limite' => now()->addDays(2)->startOfDay(),
+            'hora_limite' => '18:00',
+            'descripcion' => fake()->paragraph(),
+            'asignado' => fake()->name(),
+            'progreso' => 0,
+        ];
+    }
+}

--- a/resources/js/tasks/calendar.js
+++ b/resources/js/tasks/calendar.js
@@ -277,8 +277,8 @@ document.addEventListener('DOMContentLoaded', () => {
             </div>
             <div class="tab-panel hidden" id="tab-files">
               <div class="mb-3">
-                <label class="text-slate-300 text-sm">Carpeta de Drive</label>
-                <select id="drive-folder" class="w-full bg-slate-800 border border-slate-700 rounded px-3 py-2 text-slate-200"></select>
+                <div class="text-slate-300 text-sm">Destino en Google Drive</div>
+                <p id="drive-destination" class="text-xs text-slate-400 mt-1">Los archivos se guardarán en la carpeta "Documentos".</p>
               </div>
               <div class="flex items-center gap-2 mb-4">
                 <input type="file" id="file-input" class="text-slate-300 text-sm" />
@@ -405,12 +405,9 @@ document.addEventListener('DOMContentLoaded', () => {
         };
       }
 
-      const meetingFolderId = null;
-
-      await loadFolders(meetingFolderId); await loadFiles();
-      async function loadFolders(rootId){ const sel = modal.querySelector('#drive-folder'); const url = rootId ? `/api/drive/folders?parents=${encodeURIComponent(rootId)}` : '/api/drive/folders'; const res = await fetch(url); const data = await res.json(); sel.innerHTML=''; (data.folders||[]).forEach(f=>{ const opt=document.createElement('option'); opt.value=f.id; opt.textContent=f.name; sel.appendChild(opt); }); }
+      await loadFiles();
         async function loadFiles(){ const list = modal.querySelector('#files-list'); const res = await fetch(new URL(`/api/tasks-laravel/tasks/${t.id}/files`, window.location.origin), { credentials: 'same-origin' }); const data = await res.json(); list.innerHTML=''; (data.files||[]).forEach(f=>{ const row=document.createElement('div'); row.className='flex items-center justify-between bg-slate-800/60 border border-slate-700 rounded px-3 py-2'; const nameLink=document.createElement('a'); nameLink.href=`/api/tasks-laravel/files/${f.id}/download`; nameLink.target='_blank'; nameLink.textContent=f.name; nameLink.className='text-slate-200 hover:underline flex-1'; const preview=document.createElement('a'); preview.href=f.drive_web_link; preview.target='_blank'; preview.textContent='Vista previa'; preview.className='text-xs text-blue-400 hover:underline ml-4'; row.appendChild(nameLink); row.appendChild(preview); list.appendChild(row); }); }
-        modal.querySelector('#upload-btn').addEventListener('click', async ()=>{ const fileInput = modal.querySelector('#file-input'); const folder = modal.querySelector('#drive-folder').value; if(!fileInput.files.length){ alert('Selecciona un archivo'); return; } const fd = new FormData(); fd.append('folder_id', folder); fd.append('file', fileInput.files[0]); const r = await fetch(new URL(`/api/tasks-laravel/tasks/${t.id}/files`, window.location.origin), { method:'POST', headers:{ 'X-CSRF-TOKEN': csrf }, body: fd, credentials: 'same-origin' }); const resp = await r.json(); if(resp.success){ fileInput.value=''; await loadFiles(); } else { alert('No se pudo subir el archivo'); } });
+        modal.querySelector('#upload-btn').addEventListener('click', async ()=>{ const fileInput = modal.querySelector('#file-input'); if(!fileInput.files.length){ alert('Selecciona un archivo'); return; } const fd = new FormData(); fd.append('file', fileInput.files[0]); const r = await fetch(new URL(`/api/tasks-laravel/tasks/${t.id}/files`, window.location.origin), { method:'POST', headers:{ 'X-CSRF-TOKEN': csrf }, body: fd, credentials: 'same-origin' }); const resp = await r.json(); if(resp.success){ fileInput.value=''; await loadFiles(); } else { alert('No se pudo subir el archivo'); } });
     } catch(e){ console.error(e); alert('Error al abrir detalles de la tarea'); }
   }
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -194,7 +194,6 @@ Route::middleware(['auth'])->group(function () {
         // Archivos asociados a tareas
         Route::get('/tasks-laravel/tasks/{task}/files', [TaskAttachmentController::class, 'index'])->name('api.tasks-laravel.files.index');
         Route::post('/tasks-laravel/tasks/{task}/files', [TaskAttachmentController::class, 'store'])->name('api.tasks-laravel.files.store');
-        Route::get('/drive/folders', [TaskAttachmentController::class, 'folders'])->name('api.drive.folders');
         Route::get('/tasks-laravel/files/{file}/download', [TaskAttachmentController::class, 'download'])->name('api.tasks-laravel.files.download');
 
         // Rutas del Asistente IA

--- a/tests/Feature/TaskAttachmentControllerTest.php
+++ b/tests/Feature/TaskAttachmentControllerTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ArchivoReunion;
+use App\Models\GoogleToken;
+use App\Models\TaskLaravel;
+use App\Models\User;
+use App\Services\GoogleDriveService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Mockery;
+use Tests\TestCase;
+
+class TaskAttachmentControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_store_creates_documents_folder_when_missing(): void
+    {
+        $this->withoutMiddleware(\App\Http\Middleware\VerifyCsrfToken::class);
+
+        $user = User::factory()->create();
+        GoogleToken::create([
+            'username' => $user->username,
+            'access_token' => 'access-token',
+            'refresh_token' => 'refresh-token',
+            'recordings_folder_id' => 'root-folder',
+        ]);
+        $task = TaskLaravel::factory()->create([
+            'username' => $user->username,
+        ]);
+
+        $this->actingAs($user);
+
+        $file = UploadedFile::fake()->create('demo.pdf', 100, 'application/pdf');
+
+        $driveMock = Mockery::mock(GoogleDriveService::class);
+        $clientMock = Mockery::mock();
+
+        $driveMock->shouldReceive('setAccessToken')->once()->with('access-token');
+        $driveMock->shouldReceive('getClient')->andReturn($clientMock);
+        $clientMock->shouldReceive('isAccessTokenExpired')->andReturn(false);
+        $driveMock->shouldReceive('listFolders')
+            ->once()
+            ->with(Mockery::on(fn ($query) => str_contains($query, "Documentos") && str_contains($query, "root-folder")))
+            ->andReturn([]);
+        $driveMock->shouldReceive('createFolder')->once()->with('Documentos', 'root-folder')->andReturn('documents-folder');
+        $driveMock->shouldReceive('uploadFile')
+            ->once()
+            ->with('demo.pdf', 'application/pdf', 'documents-folder', Mockery::type('string'))
+            ->andReturn('file-123');
+        $driveMock->shouldReceive('getFileLink')->once()->with('file-123')->andReturn('https://drive.test/file-123');
+
+        $this->instance(GoogleDriveService::class, $driveMock);
+
+        $response = $this->post("/api/tasks-laravel/tasks/{$task->id}/files", [
+            'file' => $file,
+        ]);
+
+        $response->assertStatus(200)->assertJson(['success' => true]);
+
+        $this->assertDatabaseHas('archivos_reuniones', [
+            'task_id' => $task->id,
+            'drive_folder_id' => 'documents-folder',
+            'drive_file_id' => 'file-123',
+        ]);
+
+        $record = ArchivoReunion::first();
+        $this->assertSame('https://drive.test/file-123', $record->drive_web_link);
+    }
+
+    public function test_store_uses_existing_documents_folder(): void
+    {
+        $this->withoutMiddleware(\App\Http\Middleware\VerifyCsrfToken::class);
+
+        $user = User::factory()->create();
+        GoogleToken::create([
+            'username' => $user->username,
+            'access_token' => 'access-token',
+            'refresh_token' => 'refresh-token',
+            'recordings_folder_id' => 'root-folder',
+        ]);
+        $task = TaskLaravel::factory()->create([
+            'username' => $user->username,
+        ]);
+
+        $this->actingAs($user);
+
+        $file = UploadedFile::fake()->create('notas.txt', 10, 'text/plain');
+
+        $driveMock = Mockery::mock(GoogleDriveService::class);
+        $clientMock = Mockery::mock();
+
+        $driveMock->shouldReceive('setAccessToken')->once()->with('access-token');
+        $driveMock->shouldReceive('getClient')->andReturn($clientMock);
+        $clientMock->shouldReceive('isAccessTokenExpired')->andReturn(false);
+
+        $existingFolder = new class {
+            public function getId(): string
+            {
+                return 'existing-folder';
+            }
+
+            public function getName(): string
+            {
+                return 'Documentos';
+            }
+        };
+
+        $driveMock->shouldReceive('listFolders')
+            ->once()
+            ->with(Mockery::on(fn ($query) => str_contains($query, "Documentos") && str_contains($query, "root-folder")))
+            ->andReturn([$existingFolder]);
+        $driveMock->shouldReceive('createFolder')->never();
+        $driveMock->shouldReceive('uploadFile')
+            ->once()
+            ->with('notas.txt', 'text/plain', 'existing-folder', Mockery::type('string'))
+            ->andReturn('file-456');
+        $driveMock->shouldReceive('getFileLink')->once()->with('file-456')->andReturn('https://drive.test/file-456');
+
+        $this->instance(GoogleDriveService::class, $driveMock);
+
+        $response = $this->post("/api/tasks-laravel/tasks/{$task->id}/files", [
+            'file' => $file,
+        ]);
+
+        $response->assertStatus(200)->assertJson(['success' => true]);
+
+        $this->assertDatabaseHas('archivos_reuniones', [
+            'task_id' => $task->id,
+            'drive_folder_id' => 'existing-folder',
+            'drive_file_id' => 'file-456',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- crear y reutilizar automáticamente la carpeta Documentos dentro de la raíz personal al subir archivos de tareas
- simplificar el modal de archivos en el calendario indicando el destino fijo en Drive y eliminar la consulta de carpetas
- añadir fábrica y pruebas de controlador que validan la creación/uso de la carpeta Documentos y el guardado de metadatos

## Testing
- composer install *(falla: requiere autenticación de GitHub para descargar dependencias)*


------
https://chatgpt.com/codex/tasks/task_e_68cb19bdd8388323abf235f015bf02e3