### PR TITLE
Persist selected drive on change

### DIFF
--- a/resources/js/reuniones_v2.js
+++ b/resources/js/reuniones_v2.js
@@ -5172,6 +5172,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (driveSelect) {
         driveSelect.addEventListener('change', () => {
             console.log('🔄 [reuniones_v2] Drive selection changed to:', driveSelect.value);
+            sessionStorage.setItem('selectedDrive', driveSelect.value);
             loadDriveFolders();
         });
     }


### PR DESCRIPTION
## Summary
- store the selected drive in sessionStorage whenever the drive selector changes so subsequent pages can restore the choice

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cb2bf178488323b18c129d3b708d0b