### PR TITLE
Update AssemblyAI key source in transcription check

### DIFF
--- a/app/Http/Controllers/TranscriptionController.php
+++ b/app/Http/Controllers/TranscriptionController.php
@@ -870,8 +870,19 @@ class TranscriptionController extends Controller
         try {
             Log::info('Checking transcription details for debugging', ['transcription_id' => $id]);
 
+            $apiKey = config('services.assemblyai.api_key');
+            if (empty($apiKey)) {
+                Log::error('AssemblyAI API key is missing when checking transcription', [
+                    'transcription_id' => $id,
+                ]);
+
+                return response()->json([
+                    'error' => 'AssemblyAI API key is not configured.',
+                ], 500);
+            }
+
             $response = Http::withHeaders([
-                'authorization' => config('app.assemblyai_api_key'),
+                'authorization' => $apiKey,
                 'content-type' => 'application/json',
             ])->get("https://api.assemblyai.com/v2/transcript/{$id}");
 


### PR DESCRIPTION
## Summary
- load the AssemblyAI API key for transcription status checks from services configuration
- fail fast with a clear error when the AssemblyAI key is not configured

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb5c36cf548323bb6dee604d39f45b