### PR TITLE
Handle ffmpeg unavailability in chunked transcription

### DIFF
--- a/app/Exceptions/FfmpegUnavailableException.php
+++ b/app/Exceptions/FfmpegUnavailableException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+class FfmpegUnavailableException extends RuntimeException
+{
+}

--- a/app/Http/Controllers/TranscriptionController.php
+++ b/app/Http/Controllers/TranscriptionController.php
@@ -501,6 +501,7 @@ class TranscriptionController extends Controller
             'filename' => $request->input('filename'),
             'original_extension' => $extension,
             'original_mime_type' => $acceptedFormats[$extension] ?? null,
+            'supported_extensions' => array_keys($acceptedFormats),
             'conversion_target' => 'mp3',
             'conversion_required' => $extension !== 'mp3',
             'total_size' => $request->input('size'),

--- a/tests/Feature/ProcessChunkedTranscriptionJobTest.php
+++ b/tests/Feature/ProcessChunkedTranscriptionJobTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Exceptions\FfmpegUnavailableException;
 use App\Jobs\ProcessChunkedTranscription;
 use App\Services\AudioConversionService;
 use Illuminate\Http\Client\Request;
@@ -68,6 +69,7 @@ class ProcessChunkedTranscriptionJobTest extends TestCase
             'filename' => 'audio.' . $extension,
             'original_extension' => $extension,
             'original_mime_type' => $mime,
+            'supported_extensions' => ['mp3', 'wav', 'm4a', 'flac', 'ogg', 'aac', 'webm'],
             'conversion_target' => 'mp3',
             'conversion_required' => $extension !== 'mp3',
             'total_size' => $totalSize,
@@ -142,6 +144,120 @@ class ProcessChunkedTranscriptionJobTest extends TestCase
         $this->assertSame('transcript-' . $extension, $cacheData['transcription_id'] ?? null);
 
         $this->assertFileDoesNotExist($convertedPath, 'Temporary MP3 should be cleaned up after processing.');
+        $this->assertDirectoryDoesNotExist($uploadDir, 'Temporary upload directory should be removed after processing.');
+
+        app()->forgetInstance(AudioConversionService::class);
+    }
+
+    public function test_chunked_audio_uploads_original_when_ffmpeg_unavailable_for_supported_format(): void
+    {
+        config([
+            'services.assemblyai.api_key' => 'test-key',
+            'services.assemblyai.timeout' => 60,
+            'services.assemblyai.connect_timeout' => 10,
+            'services.assemblyai.verify_ssl' => true,
+        ]);
+
+        Cache::flush();
+
+        $uploadBodies = [];
+        $transcriptResponses = [];
+
+        Http::fake([
+            'https://api.assemblyai.com/v2/upload' => function (Request $request) use (&$uploadBodies) {
+                $uploadBodies[] = $request->body();
+
+                return Http::response([
+                    'upload_url' => 'https://example.com/audio.m4a',
+                ], 200);
+            },
+            'https://api.assemblyai.com/v2/transcript' => function (Request $request) use (&$transcriptResponses) {
+                $transcriptResponses[] = $request->data();
+
+                return Http::response([
+                    'id' => 'transcript-m4a',
+                ], 200);
+            },
+        ]);
+
+        $uploadId = (string) Str::uuid();
+        $trackingId = (string) Str::uuid();
+        $uploadDir = storage_path('app/temp-uploads/' . $uploadId);
+
+        if (!is_dir($uploadDir)) {
+            mkdir($uploadDir, 0755, true);
+        }
+
+        $chunks = ['first-m4a', 'second-m4a'];
+        $totalSize = 0;
+
+        foreach ($chunks as $index => $content) {
+            $chunkPath = $uploadDir . '/chunk_' . $index;
+            file_put_contents($chunkPath, $content);
+            $totalSize += strlen($content);
+        }
+
+        $metadata = [
+            'upload_id' => $uploadId,
+            'filename' => 'audio.m4a',
+            'original_extension' => 'm4a',
+            'original_mime_type' => 'audio/mp4',
+            'supported_extensions' => ['mp3', 'wav', 'm4a', 'flac', 'ogg', 'aac', 'webm'],
+            'conversion_target' => 'mp3',
+            'conversion_required' => true,
+            'total_size' => $totalSize,
+            'language' => 'es',
+            'chunks_expected' => count($chunks),
+            'chunks_received' => count($chunks),
+            'created_at' => now()->toISOString(),
+        ];
+
+        file_put_contents(
+            $uploadDir . '/metadata.json',
+            json_encode($metadata, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+
+        $fakeService = new class extends AudioConversionService {
+            public array $calls = [];
+
+            public function convertToMp3(string $filePath, ?string $mimeType = null, ?string $originalExtension = null): array
+            {
+                $this->calls[] = [
+                    'file_path' => $filePath,
+                    'mime_type' => $mimeType,
+                    'original_extension' => $originalExtension,
+                ];
+
+                throw new FfmpegUnavailableException('ffmpeg not available');
+            }
+        };
+
+        app()->instance(AudioConversionService::class, $fakeService);
+
+        $job = new ProcessChunkedTranscription($uploadId, $trackingId);
+        $job->handle();
+
+        $expectedFinalPath = $uploadDir . '/final_audio.m4a';
+
+        $this->assertSame(
+            $expectedFinalPath,
+            $fakeService->calls[0]['file_path'] ?? null,
+            'The conversion service should receive the combined file path even when FFmpeg is missing.'
+        );
+
+        $this->assertSame(
+            ['first-m4asecond-m4a'],
+            $uploadBodies,
+            'The original audio should be uploaded when FFmpeg is unavailable for a supported format.'
+        );
+
+        $this->assertNotEmpty($transcriptResponses, 'The transcript request should still be sent when falling back.');
+
+        $cacheData = Cache::get('chunked_transcription:' . $trackingId);
+        $this->assertSame('processing', $cacheData['status'] ?? null);
+        $this->assertSame('transcript-m4a', $cacheData['transcription_id'] ?? null);
+
+        $this->assertFileDoesNotExist($expectedFinalPath, 'Temporary combined audio should be cleaned up after processing.');
         $this->assertDirectoryDoesNotExist($uploadDir, 'Temporary upload directory should be removed after processing.');
 
         app()->forgetInstance(AudioConversionService::class);


### PR DESCRIPTION
## Summary
- add a dedicated `FfmpegUnavailableException` so the audio conversion service can signal when ffmpeg is missing
- fall back to uploading the combined source audio when ffmpeg is unavailable and the original extension is supported by the recorded metadata
- record the accepted audio extensions in the upload metadata and cover the new fallback path with a feature test

## Testing
- php artisan test *(fails: vendor/autoload.php missing because composer install requires a GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb67ee9f508323a10e817b6fa093a7