### PR TITLE
Handle pending audio uploads in save flow

### DIFF
--- a/tests/Feature/DriveSaveResultsRolesTest.php
+++ b/tests/Feature/DriveSaveResultsRolesTest.php
@@ -107,7 +107,7 @@ it('allows administrator to save meeting to personal drive', function () {
     $service = Mockery::mock(GoogleServiceAccount::class);
     $service->shouldReceive('shareFolder')->twice();
     $service->shouldReceive('uploadFile')->twice()->andReturn('t1', 'a1');
-    $service->shouldReceive('getFileLink')->twice()->andReturn('tlink', 'alink');
+    $service->shouldReceive('getFileLink')->twice()->andReturn('alink', 'tlink');
     app()->instance(GoogleServiceAccount::class, $service);
 
     $payload = [
@@ -161,7 +161,7 @@ it('allows administrator to save meeting to organization drive', function () {
     $service = Mockery::mock(GoogleServiceAccount::class);
     $service->shouldReceive('shareFolder')->twice();
     $service->shouldReceive('uploadFile')->twice()->andReturn('t1', 'a1');
-    $service->shouldReceive('getFileLink')->twice()->andReturn('tlink', 'alink');
+    $service->shouldReceive('getFileLink')->twice()->andReturn('alink', 'tlink');
     app()->instance(GoogleServiceAccount::class, $service);
 
     $payload = [


### PR DESCRIPTION
## Summary
- offload large blobs in the processing flow through the pending-audio upload and complete saves via /drive/save-results using the returned pending reference
- allow DriveController::saveResults to accept pending recordings, move/rename the uploaded file, and update completion metadata
- expand SaveResults feature tests to cover the pending-recording path and adjust mocks for the updated drive interactions

## Testing
- composer install *(fails: requires GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb866960548323941dfaca04545484