### PR TITLE
Allow m4a audio uploads for pending drive uploads

### DIFF
--- a/app/Http/Controllers/DriveController.php
+++ b/app/Http/Controllers/DriveController.php
@@ -375,7 +375,7 @@ class DriveController extends Controller
         try {
             $v = $request->validate([
                 'meetingName' => 'required|string',
-                'audioFile'   => 'required|file|mimetypes:audio/mpeg,audio/mp3,audio/webm,video/webm,audio/ogg,audio/wav,audio/x-wav,audio/wave,audio/mp4,video/mp4',
+                'audioFile'   => 'required|file|mimetypes:audio/mpeg,audio/mp3,audio/webm,video/webm,audio/ogg,audio/wav,audio/x-wav,audio/wave,audio/mp4,video/mp4,audio/x-m4a,audio/m4a',
                 'rootFolder'  => 'nullable|string', // Cambiar a nullable
                 'driveType'   => 'nullable|string|in:personal,organization', // Nuevo campo para tipo de drive
             ]);


### PR DESCRIPTION
## Summary
- allow the Drive pending audio upload validation to accept m4a MIME types
- add a feature test confirming that an m4a upload is processed successfully

## Testing
- `php artisan test --filter=DriveUploadPendingAudioTest` *(fails: missing vendor autoload and Composer could not install dependencies due to GitHub 403 when downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68cb91e47e648323ba1fa840f19ff684