### PR TITLE
Support OGG audio defaults across controllers

### DIFF
--- a/app/Http/Controllers/DriveController.php
+++ b/app/Http/Controllers/DriveController.php
@@ -405,7 +405,7 @@ class DriveController extends Controller
         try {
             $v = $request->validate([
                 'meetingName' => 'required|string',
-                'audioFile'   => 'required|file|mimetypes:audio/mpeg,audio/mp3,audio/webm,video/webm,audio/ogg,audio/wav,audio/x-wav,audio/wave,audio/mp4,video/mp4',
+                'audioFile'   => 'required|file|mimetypes:audio/*',
                 'rootFolder'  => 'nullable|string', // Cambiar a nullable
                 'driveType'   => 'nullable|string|in:personal,organization', // Nuevo campo para tipo de drive
             ]);
@@ -594,19 +594,35 @@ class DriveController extends Controller
             }
             $filePath = $file->getRealPath();
             $mime = $file->getMimeType();
+            $baseMime = explode(';', strtolower($mime))[0];
             $mimeToExt = [
-                'audio/mpeg' => 'mp3',
-                'audio/mp3'  => 'mp3',
-                'audio/webm' => 'webm',
-                'video/webm' => 'webm',
-                'audio/ogg'  => 'ogg',
-                'audio/wav'  => 'wav',
-                'audio/x-wav' => 'wav',
-                'audio/wave' => 'wav',
-                'audio/mp4'  => 'mp4',
+                'audio/mpeg'       => 'mp3',
+                'audio/mp3'        => 'mp3',
+                'audio/aac'        => 'aac',
+                'audio/x-aac'      => 'aac',
+                'audio/mp4'        => 'm4a',
+                'audio/x-m4a'      => 'm4a',
+                'audio/m4a'        => 'm4a',
+                'audio/webm'       => 'webm',
+                'video/webm'       => 'webm',
+                'audio/ogg'        => 'ogg',
+                'application/ogg'  => 'ogg',
+                'audio/opus'       => 'opus',
+                'audio/ogg;codecs=opus' => 'ogg',
+                'audio/x-opus+ogg' => 'ogg',
+                'audio/wav'        => 'wav',
+                'audio/x-wav'      => 'wav',
+                'audio/wave'       => 'wav',
+                'audio/flac'       => 'flac',
+                'audio/x-flac'     => 'flac',
+                'audio/amr'        => 'amr',
+                'audio/3gpp'       => '3gp',
+                'audio/3gpp2'      => '3g2',
             ];
-            $baseMime = explode(';', $mime)[0];
-            $ext = $mimeToExt[$baseMime] ?? preg_replace('/[^\w]/', '', explode('/', $baseMime, 2)[1] ?? '');
+            $ext = $mimeToExt[$baseMime] ?? null;
+            if (empty($ext)) {
+                $ext = 'ogg';
+            }
             $fileName = $v['meetingName'] . '.' . $ext;
 
             Log::debug('uploadPendingAudio uploading to Drive', [
@@ -756,18 +772,35 @@ class DriveController extends Controller
 
         // Determine a suitable extension from the mime type
         $mime = strtolower($v['audioMimeType']);
-        $mimeToExt = [
-            'audio/mpeg' => 'mp3',
-            'audio/mp3'  => 'mp3',
-            'audio/webm' => 'webm',
-            'audio/ogg'  => 'ogg',
-            'audio/wav'  => 'wav',
-            'audio/x-wav' => 'wav',
-            'audio/wave' => 'wav',
-            'audio/mp4'  => 'mp4',
-        ];
         $baseMime = explode(';', $mime)[0];
-        $ext = $mimeToExt[$baseMime] ?? preg_replace('/[^\w]/', '', explode('/', $baseMime, 2)[1] ?? '');
+        $mimeToExt = [
+            'audio/mpeg'       => 'mp3',
+            'audio/mp3'        => 'mp3',
+            'audio/aac'        => 'aac',
+            'audio/x-aac'      => 'aac',
+            'audio/mp4'        => 'm4a',
+            'audio/x-m4a'      => 'm4a',
+            'audio/m4a'        => 'm4a',
+            'audio/webm'       => 'webm',
+            'audio/ogg'        => 'ogg',
+            'application/ogg'  => 'ogg',
+            'audio/x-opus+ogg' => 'ogg',
+            'audio/opus'       => 'opus',
+            'video/webm'       => 'webm',
+            'video/mp4'        => 'mp4',
+            'audio/wav'        => 'wav',
+            'audio/x-wav'      => 'wav',
+            'audio/wave'       => 'wav',
+            'audio/flac'       => 'flac',
+            'audio/x-flac'     => 'flac',
+            'audio/amr'        => 'amr',
+            'audio/3gpp'       => '3gp',
+            'audio/3gpp2'      => '3g2',
+        ];
+        $ext = $mimeToExt[$baseMime] ?? null;
+        if (empty($ext)) {
+            $ext = 'ogg';
+        }
 
         // Upload the audio file to Drive using the pending folder as parent
         $fileId = $serviceAccount->uploadFile(
@@ -989,19 +1022,35 @@ class DriveController extends Controller
 
                 // extrae la extensión a partir del mimeType usando un mapa conocido
                 $mime = strtolower($v['audioMimeType']);
-                $mimeToExt = [
-                    'audio/mpeg' => 'mp3',
-                    'audio/mp3'  => 'mp3',
-                    'audio/webm' => 'webm',
-                    'audio/ogg'  => 'ogg',
-                    'audio/wav'  => 'wav',
-                    'audio/x-wav' => 'wav',
-                    'audio/wave' => 'wav',
-                    'audio/mp4'  => 'mp4',
-                ];
                 $baseMime = explode(';', $mime)[0];
-                $ext      = $mimeToExt[$baseMime]
-                    ?? preg_replace('/[^\\w]/', '', explode('/', $baseMime, 2)[1] ?? '');
+                $mimeToExt = [
+                    'audio/mpeg'       => 'mp3',
+                    'audio/mp3'        => 'mp3',
+                    'audio/aac'        => 'aac',
+                    'audio/x-aac'      => 'aac',
+                    'audio/mp4'        => 'm4a',
+                    'audio/x-m4a'      => 'm4a',
+                    'audio/m4a'        => 'm4a',
+                    'audio/webm'       => 'webm',
+                    'audio/ogg'        => 'ogg',
+                    'application/ogg'  => 'ogg',
+                    'audio/x-opus+ogg' => 'ogg',
+                    'audio/opus'       => 'opus',
+                    'audio/wav'        => 'wav',
+                    'audio/x-wav'      => 'wav',
+                    'audio/wave'       => 'wav',
+                    'audio/flac'       => 'flac',
+                    'audio/x-flac'     => 'flac',
+                    'audio/amr'        => 'amr',
+                    'audio/3gpp'       => '3gp',
+                    'audio/3gpp2'      => '3g2',
+                    'video/webm'       => 'webm',
+                    'video/mp4'        => 'mp4',
+                ];
+                $ext      = $mimeToExt[$baseMime] ?? null;
+                if (empty($ext)) {
+                    $ext = 'ogg';
+                }
 
                 $audioFileId = $serviceAccount
                     ->uploadFile("{$meetingName}.{$ext}", $v['audioMimeType'], $audioFolderId, $tmp);

--- a/tests/Feature/DriveControllerSaveResultsTest.php
+++ b/tests/Feature/DriveControllerSaveResultsTest.php
@@ -87,7 +87,7 @@ it('derives the audio extension from the mime type map', function () {
     $service->shouldReceive('uploadFile')
         ->once()->with('Meeting.ju', 'application/json', 'trans123', Mockery::type('string'))->ordered()->andReturn('t1');
     $service->shouldReceive('uploadFile')
-        ->once()->with('Meeting.mp3', 'audio/mpeg', 'audio123', Mockery::type('string'))->ordered()->andReturn('a1');
+        ->once()->with('Meeting.ogg', 'audio/ogg', 'audio123', Mockery::type('string'))->ordered()->andReturn('a1');
     $service->shouldReceive('getFileLink')
         ->twice()->ordered()->andReturn('tlink', 'alink');
 
@@ -107,7 +107,7 @@ it('derives the audio extension from the mime type map', function () {
             'tasks' => [],
         ],
         'audioData' => base64_encode('audio'),
-        'audioMimeType' => 'audio/mpeg',
+        'audioMimeType' => 'audio/ogg',
     ];
 
     $response = $this->actingAs($user)->post('/drive/save-results', $payload);

--- a/tests/Feature/MeetingEndpointsTest.php
+++ b/tests/Feature/MeetingEndpointsTest.php
@@ -214,7 +214,7 @@ test('show legacy meeting returns audio data', function () {
         public function setAccessToken($token) {}
         public function getClient() { return new class { public function isAccessTokenExpired(){ return false; } }; }
         public function downloadFileContent($fileId) { return json_encode(['summary' => 's', 'key_points' => [], 'transcription' => 't']); }
-        public function findAudioInFolder($folderId, $meetingTitle, $meetingId) { return ['fileId' => 'file456', 'downloadUrl' => 'https://example.com/audio.mp3']; }
+        public function findAudioInFolder($folderId, $meetingTitle, $meetingId) { return ['fileId' => 'file456', 'downloadUrl' => 'https://example.com/audio.ogg']; }
         public function getFileInfo($fileId) { return new class { public function getParents(){ return []; } public function getName(){ return 'Parent'; } }; }
     });
 
@@ -222,7 +222,7 @@ test('show legacy meeting returns audio data', function () {
 
     $response->assertOk()
         ->assertJsonFragment([
-            'audio_path' => 'https://example.com/audio.mp3',
+            'audio_path' => 'https://example.com/audio.ogg',
             'audio_drive_id' => 'file456',
             'is_legacy' => true,
         ]);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -51,7 +51,7 @@ function createLegacyMeeting(User $user, array $attributes = []): TranscriptionL
         'username' => $user->username,
         'meeting_name' => 'Legacy Meeting ' . Str::random(6),
         'audio_drive_id' => 'audio-' . Str::uuid(),
-        'audio_download_url' => 'https://example.test/audio.mp3',
+        'audio_download_url' => 'https://example.test/audio.ogg',
         'transcript_drive_id' => 'transcript-' . Str::uuid(),
         'transcript_download_url' => 'https://example.test/transcript.json',
     ];


### PR DESCRIPTION
## Summary
- broaden DriveController audio validation to accept any audio MIME type, expand the MIME-to-extension map, and fall back to OGG names
- relax transcription uploads to allow OGG/WebM inputs while applying a neutral AssemblyAI configuration for all audio formats
- default MeetingController streaming fallbacks to OGG resources and update feature tests to expect OGG filenames and MIME types

## Testing
- `php artisan test` *(fails: missing vendor/autoload.php because dependencies are not installed)*
- `composer install` *(fails: GitHub responded 403 while downloading symfony/polyfill-mbstring without credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68cc548cf030832383eb35c681732705