### PR TITLE
Ensure default recordings folder is created under configured root

### DIFF
--- a/app/Http/Controllers/DriveController.php
+++ b/app/Http/Controllers/DriveController.php
@@ -558,7 +558,16 @@ class DriveController extends Controller
                         $driveService = app(\App\Services\GoogleDriveService::class);
                         $driveService->setToken($token);
 
-                        $folderId = $driveService->createFolder($defaultFolderName);
+                        $parentRootFolderId = config('drive.root_folder_id');
+                        if (empty($parentRootFolderId)) {
+                            Log::error('uploadPendingAudio: missing configured root folder id for default creation', [
+                                'username' => $user->username,
+                            ]);
+
+                            return response()->json(['message' => 'Carpeta raíz de Drive no configurada'], 500);
+                        }
+
+                        $folderId = $driveService->createFolder($defaultFolderName, $parentRootFolderId);
 
                         // Save the folder to database
                         $rootFolder = Folder::create([
@@ -571,7 +580,8 @@ class DriveController extends Controller
                         Log::info('uploadPendingAudio: default root folder created', [
                             'username' => $user->username,
                             'folder_id' => $folderId,
-                            'folder_name' => $defaultFolderName
+                            'folder_name' => $defaultFolderName,
+                            'parent_root_id' => $parentRootFolderId,
                         ]);
 
                     } catch (\Exception $e) {


### PR DESCRIPTION
## Summary
- validate that the configured Drive root folder exists before creating the default "Grabaciones" folder
- pass the configured parent folder id to the Drive service when creating the default root folder
- improve logging around default folder creation to clarify the expected parent folder configuration

## Testing
- `php artisan test` *(fails: missing vendor directory before dependencies installation)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6cfc066c8323b0b0872959d28206