### PR TITLE
Ensure organization root folders use configured parent

### DIFF
--- a/app/Http/Controllers/OrganizationDriveController.php
+++ b/app/Http/Controllers/OrganizationDriveController.php
@@ -89,9 +89,18 @@ class OrganizationDriveController extends Controller
         if (!$this->userCanManage($organization)) {
             abort(403, 'No autorizado');
         }
+
+        $parentFolderId = config('drive.root_folder_id');
+        if (empty($parentFolderId)) {
+            Log::error('Google Drive root folder ID is not configured.');
+
+            return response()->json([
+                'message' => 'El ID de la carpeta raíz de Google Drive no está configurado.',
+            ], 500);
+        }
         $token = $this->initDrive($organization);
 
-        $folderId = $this->drive->createFolder($organization->nombre_organizacion);
+        $folderId = $this->drive->createFolder($organization->nombre_organizacion, $parentFolderId);
 
         $folder = OrganizationFolder::create([
             'organization_id' => $organization->id,


### PR DESCRIPTION
## Summary
- ensure organization root folder creation validates the configured Drive container before making API calls
- pass the configured container ID when creating a new organization root folder in Drive
- cover the new behaviour with a missing configuration test and update mocks to expect the parent folder argument

## Testing
- composer install *(fails: requires GitHub token to download voku/portable-ascii)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6d10f5dc8323b82584ef3e11f774