### PR TITLE
Update formatTime to return HH:MM:SS

### DIFF
--- a/resources/js/reuniones_v2.js
+++ b/resources/js/reuniones_v2.js
@@ -3191,9 +3191,13 @@ function seekAudio(segmentIndex, event) {
 
 function formatTime(ms) {
     const totalSeconds = Math.floor(ms / 1000);
-    const minutes = String(Math.floor(totalSeconds / 60)).padStart(2, '0');
-    const seconds = String(totalSeconds % 60).padStart(2, '0');
-    return `${minutes}:${seconds}`;
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    return [hours, minutes, seconds]
+        .map((value) => String(value).padStart(2, '0'))
+        .join(':');
 }
 
 // ===============================================


### PR DESCRIPTION
## Summary
- update the formatTime utility to always produce HH:MM:SS timestamps for meeting segments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd6e040fe48323ade7a51db5c871cd