### PR TITLE
Add Documentos standard folder support

### DIFF
--- a/app/Http/Controllers/DriveController.php
+++ b/app/Http/Controllers/DriveController.php
@@ -40,10 +40,11 @@ class DriveController extends Controller
     }
 
     /**
-     * Ensure the three standard subfolders exist under the provided root folder:
+     * Ensure the four standard subfolders exist under the provided root folder:
      *  - Audios
      *  - Transcripciones
      *  - Audios Pospuestos
+     *  - Documentos
      * Works for both personal and organization drives, creating missing folders in Google Drive
      * and persisting them in the corresponding DB tables. Returns an associative array with the
      * Subfolder / OrganizationSubfolder models: ['audio' => ..., 'transcription' => ..., 'pending' => ...]
@@ -54,6 +55,7 @@ class DriveController extends Controller
             'audio'         => 'Audios',
             'transcription' => 'Transcripciones',
             'pending'       => 'Audios Pospuestos',
+            'documents'     => 'Documentos',
         ];
 
         $result = [];
@@ -394,7 +396,7 @@ class DriveController extends Controller
         // Ensure standard subfolders exist in the new personal root (idempotent) using SA
         try {
             $serviceEmail = config('services.google.service_account_email');
-            $needed = ['Audios', 'Transcripciones', 'Audios Pospuestos'];
+            $needed = ['Audios', 'Transcripciones', 'Audios Pospuestos', 'Documentos'];
             foreach ($needed as $name) {
                 try {
                     $subId = $serviceAccount->createFolder($name, $folderId);
@@ -489,7 +491,7 @@ class DriveController extends Controller
             foreach ($subfolders as $sf) {
                 $existing[strtolower($sf->name)] = true;
             }
-            $needed = ['Audios', 'Transcripciones', 'Audios Pospuestos'];
+            $needed = ['Audios', 'Transcripciones', 'Audios Pospuestos', 'Documentos'];
             foreach ($needed as $name) {
                 if (!isset($existing[strtolower($name)])) {
                     try {
@@ -526,7 +528,7 @@ class DriveController extends Controller
     {
         return response()->json([
             'deprecated' => true,
-            'message' => 'La creación manual de subcarpetas fue deshabilitada. Ahora se crean automáticamente (Audios, Transcripciones, Audios Pospuestos).'
+            'message' => 'La creación manual de subcarpetas fue deshabilitada. Ahora se crean automáticamente (Audios, Transcripciones, Audios Pospuestos, Documentos).'
         ], 410);
     }
 

--- a/app/Http/Controllers/OrganizationDriveController.php
+++ b/app/Http/Controllers/OrganizationDriveController.php
@@ -181,7 +181,7 @@ class OrganizationDriveController extends Controller
         // Ensure standard subfolders exist for organization root
         try {
             $serviceEmail = config('services.google.service_account_email');
-            $needed = ['Audios', 'Transcripciones', 'Audios Pospuestos'];
+            $needed = ['Audios', 'Transcripciones', 'Audios Pospuestos', 'Documentos'];
             foreach ($needed as $name) {
                 try {
                     $subId = $serviceAccount->createFolder($name, $folderId);

--- a/resources/views/audio-processing.blade.php
+++ b/resources/views/audio-processing.blade.php
@@ -299,7 +299,7 @@
 
                             <!-- Selector de carpeta principal eliminado: ahora se determina automáticamente según el Drive seleccionado -->
 
-                            <!-- Subcarpetas manuales eliminadas: ahora se usan carpetas fijas (Audios, Transcripciones, Audios Pospuestos) -->
+                            <!-- Subcarpetas manuales eliminadas: ahora se usan carpetas fijas (Audios, Transcripciones, Audios Pospuestos, Documentos) -->
 
                             <div class="form-group">
                                 <label class="form-label">Nombre de la reunión</label>
@@ -308,7 +308,7 @@
 
                             <div class="form-group" style="font-size:0.85rem; line-height:1.4; color:#94a3b8;">
                                 <strong>Estructura automática:</strong> Los resultados se guardarán en carpetas fijas dentro de tu carpeta principal:
-                                <em>Audios</em>, <em>Transcripciones</em> y <em>Audios Pospuestos</em>. Ya no es necesario elegir subcarpetas manualmente.
+                                <em>Audios</em>, <em>Transcripciones</em>, <em>Audios Pospuestos</em> y <em>Documentos</em>. Ya no es necesario elegir subcarpetas manualmente.
                             </div>
                         </div>
                     </div>

--- a/resources/views/organization/drive.blade.php
+++ b/resources/views/organization/drive.blade.php
@@ -47,7 +47,7 @@
             <h2 class="font-medium mb-2">Estructura de almacenamiento</h2>
             <p class="text-sm text-gray-600 leading-relaxed">
                 Las subcarpetas ahora se crean y usan automáticamente. El sistema gestionará las carpetas
-                <strong>Audios</strong>, <strong>Transcripciones</strong> y <strong>Audios Pospuestos</strong> dentro de la carpeta principal.
+                <strong>Audios</strong>, <strong>Transcripciones</strong>, <strong>Audios Pospuestos</strong> y <strong>Documentos</strong> dentro de la carpeta principal.
                 No es necesario crear ni administrar subcarpetas manualmente.
             </p>
         </div>

--- a/resources/views/organization/index.blade.php
+++ b/resources/views/organization/index.blade.php
@@ -231,7 +231,7 @@
                                         <div class="mt-4">
                                             <h4 class="font-semibold mb-3">Estructura de almacenamiento</h4>
                                             <p class="text-slate-400 text-sm leading-relaxed">
-                                                Las subcarpetas se gestionan automáticamente. El sistema usa las carpetas fijas <strong>Audios</strong>, <strong>Transcripciones</strong> y <strong>Audios Pospuestos</strong> dentro de la carpeta raíz de la organización. No necesitas crear subcarpetas manualmente.
+                                                Las subcarpetas se gestionan automáticamente. El sistema usa las carpetas fijas <strong>Audios</strong>, <strong>Transcripciones</strong>, <strong>Audios Pospuestos</strong> y <strong>Documentos</strong> dentro de la carpeta raíz de la organización. No necesitas crear subcarpetas manualmente.
                                             </p>
                                         </div>
                                     </div>

--- a/resources/views/partials/profile/_section-connect.blade.php
+++ b/resources/views/partials/profile/_section-connect.blade.php
@@ -154,6 +154,7 @@
                         <li><strong>Audios</strong>: Archivos de audio finales</li>
                         <li><strong>Transcripciones</strong>: Archivos .ju encriptados con la transcripción y resumen</li>
                         <li><strong>Audios Pospuestos</strong>: Audios subidos pendientes de completar</li>
+                        <li><strong>Documentos</strong>: Exportaciones y archivos adicionales relacionados a la reunión</li>
                     </ul>
                     No necesitas crear subcarpetas manualmente. Esta sección reemplaza la antigua gestión de subcarpetas.
                 </div>

--- a/tests/Feature/DriveControllerMainFolderTest.php
+++ b/tests/Feature/DriveControllerMainFolderTest.php
@@ -47,6 +47,9 @@ it('creates main folder', function () {
     $serviceAccount->shouldReceive('createFolder')
         ->with('Audios Pospuestos', 'folder123')
         ->andReturn('pospuestos');
+    $serviceAccount->shouldReceive('createFolder')
+        ->with('Documentos', 'folder123')
+        ->andReturn('documentos');
     $serviceAccount->shouldReceive('shareFolder')->andReturnNull();
 
     app()->instance(GoogleDriveService::class, $service);
@@ -109,6 +112,9 @@ it('shares main folder with the service account email', function () {
     $serviceAccount->shouldReceive('createFolder')
         ->with('Audios Pospuestos', 'folder123')
         ->andReturn('pospuestos');
+    $serviceAccount->shouldReceive('createFolder')
+        ->with('Documentos', 'folder123')
+        ->andReturn('documentos');
     $serviceAccount->shouldReceive('shareFolder')->andReturnNull();
 
     app()->instance(GoogleDriveService::class, $service);
@@ -201,6 +207,9 @@ it('falls back to oauth client when service account cannot create main folder', 
     $serviceAccount->shouldReceive('createFolder')
         ->with('Audios Pospuestos', 'folder123')
         ->andReturn('pospuestos');
+    $serviceAccount->shouldReceive('createFolder')
+        ->with('Documentos', 'folder123')
+        ->andReturn('documentos');
     $serviceAccount->shouldReceive('shareFolder')->andReturnNull();
 
     app()->instance(GoogleDriveService::class, $service);

--- a/tests/Feature/DriveControllerSaveResultsTest.php
+++ b/tests/Feature/DriveControllerSaveResultsTest.php
@@ -120,6 +120,10 @@ it('retries personal subfolder creation with impersonation when required', funct
         ->with('Audios Pospuestos', 'root123')
         ->once()
         ->andReturn('pending-id');
+    $service->shouldReceive('createFolder')
+        ->with('Documentos', 'root123')
+        ->once()
+        ->andReturn('documents-id');
     $service->shouldReceive('shareFolder')->zeroOrMoreTimes()->andReturnNull();
     $service->shouldReceive('uploadFile')->twice()->andReturn('t1', 'a1');
     $service->shouldReceive('getFileLink')->twice()->andReturn('tlink', 'alink');
@@ -144,9 +148,9 @@ it('retries personal subfolder creation with impersonation when required', funct
     $response->assertOk();
 
     $subfolders = Subfolder::where('folder_id', $rootFolder->id)->get();
-    expect($subfolders)->toHaveCount(3);
+    expect($subfolders)->toHaveCount(4);
     expect($subfolders->pluck('folder_id')->unique()->all())->toEqual([$rootFolder->id]);
-    expect($subfolders->pluck('name')->sort()->values()->all())->toEqual(['Audios', 'Audios Pospuestos', 'Transcripciones']);
+    expect($subfolders->pluck('name')->sort()->values()->all())->toEqual(['Audios', 'Audios Pospuestos', 'Documentos', 'Transcripciones']);
 });
 
 it('impersonates the organization connector when creating missing subfolders', function () {
@@ -192,6 +196,8 @@ it('impersonates the organization connector when creating missing subfolders', f
     $service->shouldReceive('createFolder')->with('Transcripciones', 'org-root')->once()->ordered('trans')->andReturn('org-trans');
     $service->shouldReceive('impersonate')->with('admin@example.com')->once()->ordered('pending');
     $service->shouldReceive('createFolder')->with('Audios Pospuestos', 'org-root')->once()->ordered('pending')->andReturn('org-pending');
+    $service->shouldReceive('impersonate')->with('admin@example.com')->once()->ordered('documents');
+    $service->shouldReceive('createFolder')->with('Documentos', 'org-root')->once()->ordered('documents')->andReturn('org-documents');
     $service->shouldReceive('impersonate')->with(null)->once();
     $service->shouldReceive('shareFolder')->zeroOrMoreTimes()->andReturnNull();
     $service->shouldReceive('uploadFile')->twice()->andReturn('t1', 'a1');
@@ -218,9 +224,9 @@ it('impersonates the organization connector when creating missing subfolders', f
     $response->assertOk();
 
     $subfolders = OrganizationSubfolder::where('organization_folder_id', $rootFolder->id)->get();
-    expect($subfolders)->toHaveCount(3);
+    expect($subfolders)->toHaveCount(4);
     expect($subfolders->pluck('organization_folder_id')->unique()->all())->toEqual([$rootFolder->id]);
-    expect($subfolders->pluck('name')->sort()->values()->all())->toEqual(['Audios', 'Audios Pospuestos', 'Transcripciones']);
+    expect($subfolders->pluck('name')->sort()->values()->all())->toEqual(['Audios', 'Audios Pospuestos', 'Documentos', 'Transcripciones']);
 });
 
 it('derives the audio extension from the mime type map', function () {

--- a/tests/Feature/OrganizationDriveRootFolderTest.php
+++ b/tests/Feature/OrganizationDriveRootFolderTest.php
@@ -59,6 +59,9 @@ it('allows administrator to create organization root folder', function () {
     $serviceAccount->shouldReceive('createFolder')
         ->with('Audios Pospuestos', 'root123')
         ->andReturn('pospuestos');
+    $serviceAccount->shouldReceive('createFolder')
+        ->with('Documentos', 'root123')
+        ->andReturn('documentos');
     $serviceAccount->shouldReceive('shareFolder')->andReturnNull();
 
     app()->instance(GoogleDriveService::class, $drive);
@@ -122,6 +125,9 @@ it('falls back to oauth client when service account cannot create root folder', 
     $serviceAccount->shouldReceive('createFolder')
         ->with('Audios Pospuestos', 'root123')
         ->andReturn('pospuestos');
+    $serviceAccount->shouldReceive('createFolder')
+        ->with('Documentos', 'root123')
+        ->andReturn('documentos');
     $serviceAccount->shouldReceive('shareFolder')->andReturnNull();
 
     app()->instance(GoogleDriveService::class, $drive);


### PR DESCRIPTION
## Summary
- ensure the shared Drive provisioning utilities manage the new fixed "Documentos" subfolder alongside the existing three standard folders
- mention the automatic "Documentos" subfolder across the relevant user-facing views and API messaging
- extend feature tests to expect creation and tracking of the four standard subfolders in both personal and organization contexts

## Testing
- `./vendor/bin/pest tests/Feature/DriveControllerMainFolderTest.php tests/Feature/DriveControllerSaveResultsTest.php tests/Feature/OrganizationDriveRootFolderTest.php` *(fails: vendor binaries unavailable without installing dependencies)*
- `composer install` *(fails: GitHub 403 when downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68cd753a63ec832389520ad78ee314df