### PR TITLE
Add mixed context type to AI chat sessions

### DIFF
--- a/database/migrations/2025_01_16_000000_update_context_type_in_ai_chat_sessions_table.php
+++ b/database/migrations/2025_01_16_000000_update_context_type_in_ai_chat_sessions_table.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\\Database\\Migrations\\Migration;
+use Illuminate\\Support\\Facades\\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement("ALTER TABLE ai_chat_sessions MODIFY context_type ENUM('general','container','meeting','contact_chat','documents','mixed') DEFAULT 'general'");
+    }
+
+    public function down(): void
+    {
+        DB::statement("ALTER TABLE ai_chat_sessions MODIFY context_type ENUM('general','container','meeting','contact_chat','documents') DEFAULT 'general'");
+    }
+};

--- a/tests/Feature/AiAssistantMixedContextTest.php
+++ b/tests/Feature/AiAssistantMixedContextTest.php
@@ -52,7 +52,9 @@ test('ai assistant mixed context session returns meeting fragments', function ()
         ],
     ]);
 
-    $sessionResponse->assertOk()->assertJsonPath('success', true);
+    $sessionResponse->assertOk()
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('session.context_type', 'mixed');
     $sessionId = $sessionResponse->json('session.id');
 
     $messageResponse = $this->postJson("/api/ai-assistant/sessions/{$sessionId}/messages", [


### PR DESCRIPTION
## Summary
- extend the ai_chat_sessions.context_type column to accept the new `mixed` option via a schema migration
- tighten the mixed context feature test to assert the stored session keeps the `mixed` context type

## Testing
- not run (framework dependencies missing locally)

------
https://chatgpt.com/codex/tasks/task_e_68cda1f9bb10832398939cbe6cdec853