### PR TITLE
Adjust assistant message colors

### DIFF
--- a/public/css/ai-assistant.css
+++ b/public/css/ai-assistant.css
@@ -250,8 +250,8 @@
 }
 
 .message.user .message-avatar {
-    background: rgba(251, 191, 36, 0.1);
-    border: 1px solid rgba(251, 191, 36, 0.3);
+    background: rgba(251, 191, 36, 0.15);
+    border: 1px solid rgba(251, 191, 36, 0.4);
     color: #fbbf24;
 }
 
@@ -274,15 +274,15 @@
 }
 
 .message.ai .message-bubble {
-    background: rgba(30, 41, 59, 0.6);
-    border: 1px solid rgba(59, 130, 246, 0.1);
-    color: #e2e8f0;
+    background: rgba(37, 99, 235, 0.15);
+    border: 1px solid rgba(59, 130, 246, 0.4);
+    color: #dbeafe;
 }
 
 .message.user .message-bubble {
-    background: rgba(59, 130, 246, 0.1);
-    border: 1px solid rgba(59, 130, 246, 0.3);
-    color: #e2e8f0;
+    background: rgba(251, 191, 36, 0.2);
+    border: 1px solid rgba(251, 191, 36, 0.5);
+    color: #1f2937;
 }
 
 .message-citations {


### PR DESCRIPTION
## Summary
- update user message avatars and bubbles to use a warm yellow palette with high-contrast text
- refresh AI message bubble styling to keep a cohesive blue color scheme

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cda6f390b88323bbf9fc40c367fa5a