### PR TITLE
Update chat session title after first user message

### DIFF
--- a/public/js/ai-assistant.js
+++ b/public/js/ai-assistant.js
@@ -284,7 +284,7 @@ function updateSessionInfo(session) {
     if (!session) return;
 
     // Actualizar el título de la sesión si existe un elemento para ello
-    const sessionTitle = document.getElementById('sessionTitle');
+    const sessionTitle = document.getElementById('current-session-title') || document.getElementById('sessionTitle');
     if (sessionTitle && session.title) {
         sessionTitle.textContent = session.title;
     }
@@ -421,6 +421,11 @@ async function sendMessage(messageText = null) {
         if (data.success) {
             // Agregar respuesta de la IA
             addMessageToChat(data.assistant_message);
+
+            if (data.session) {
+                updateSessionInfo(data.session);
+                await loadChatSessions();
+            }
         } else {
             throw new Error(data.message || 'Error al enviar mensaje');
         }


### PR DESCRIPTION
## Summary
- derive and persist a chat session title after the first user message in `sendMessage`
- return the refreshed session payload so the frontend can react to title changes
- refresh the chat sessions list and header title when the backend sends updated session data

## Testing
- php artisan test *(fails: missing `vendor/autoload.php`)*

------
https://chatgpt.com/codex/tasks/task_e_68cda9a37b4c83238cfa8d80329fb560