### PR TITLE
Handle missing key points relation in AI assistant

### DIFF
--- a/tests/Feature/AiAssistant/AiAssistantControllerMissingKeyPointsTableTest.php
+++ b/tests/Feature/AiAssistant/AiAssistantControllerMissingKeyPointsTableTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Http\Middleware\VerifyCsrfToken;
+use App\Models\AiChatSession;
+use App\Models\User;
+use App\Services\AiChatService;
+use App\Services\EmbeddingSearch;
+use Illuminate\Support\Facades\Schema;
+
+test('ai assistant meeting context works without key points table', function () {
+    Schema::dropIfExists('key_points');
+
+    $user = User::factory()->create(['username' => 'missing-key-points-user']);
+    $meeting = createLegacyMeeting($user);
+
+    $session = AiChatSession::query()->create([
+        'username' => $user->username,
+        'title' => 'Meeting Context',
+        'context_type' => 'meeting',
+        'context_id' => $meeting->id,
+        'context_data' => [],
+        'is_active' => true,
+        'last_activity' => now(),
+    ]);
+
+    app()->instance(EmbeddingSearch::class, new class () {
+        public function search(string $username, string $query, array $options = []): array
+        {
+            return [];
+        }
+    });
+
+    app()->instance(AiChatService::class, new class () {
+        public function generateReply(AiChatSession $session, ?string $systemMessage = null, array $context = []): array
+        {
+            return [
+                'content' => 'Respuesta de prueba',
+                'metadata' => [
+                    'context_fragments' => $context,
+                ],
+            ];
+        }
+    });
+
+    $this->withoutMiddleware([VerifyCsrfToken::class]);
+    $this->actingAs($user);
+
+    $response = $this->postJson("/api/ai-assistant/sessions/{$session->id}/messages", [
+        'content' => 'Hola asistente',
+    ]);
+
+    $response->assertOk()->assertJsonPath('success', true);
+
+    $this->assertDatabaseHas('ai_chat_messages', [
+        'session_id' => $session->id,
+        'role' => 'assistant',
+    ]);
+});


### PR DESCRIPTION
## Summary
- load meeting key point relations in the AI assistant only when the key_points table exists and default missing relations to an empty collection
- cover the missing-table scenario with a feature test that exercises the AI assistant message endpoint

## Testing
- Unable to run tests: composer install could not download dependencies in the sandbox environment

------
https://chatgpt.com/codex/tasks/task_e_68cdabbbfa0883239cc3f727129ce5ec