### PR TITLE
Increase meeting modal z-index

### DIFF
--- a/resources/css/reuniones_v2.css
+++ b/resources/css/reuniones_v2.css
@@ -486,7 +486,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1000;
+    z-index: 10050;
     padding: 1rem; /* Reducido de 2rem a 1rem para pantallas pequeñas */
     opacity: 0;
     pointer-events: none;


### PR DESCRIPTION
## Summary
- raise the meeting details modal z-index so it sits above any other overlays on the meetings page
- confirmed that existing share and container-related modals keep lower stacking values to avoid conflicts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdd347eafc8323abb4f0aea3248688