### PR TITLE
Ensure stream audio fallback impersonation

### DIFF
--- a/app/Http/Controllers/MeetingController.php
+++ b/app/Http/Controllers/MeetingController.php
@@ -2182,7 +2182,7 @@ class MeetingController extends Controller
                             ]);
                             $dbg['getAudioPath_exception'] = $eGet->getMessage();
                             // Fallback inmediato: reutilizar la lógica de descarga directa estilo downloadAudioFile
-                            $fallback = $this->resolveLegacyAudio($meetingModel, $sharedAccess, null, $debug, $dbg);
+                            $fallback = $this->resolveLegacyAudio($meetingModel, $sharedAccess, $sharedMeeting, $debug, $dbg);
                             if ($fallback instanceof \Illuminate\Http\JsonResponse || $fallback instanceof \Illuminate\Http\RedirectResponse || $fallback instanceof \Symfony\Component\HttpFoundation\Response) {
                                 return $fallback;
                             }
@@ -2196,7 +2196,7 @@ class MeetingController extends Controller
                             'audio_download_url' => $meetingModel->audio_download_url
                         ]);
                         // Fallback final: intentar flujo directo sin crear archivo temporal
-                        $fallback = $this->resolveLegacyAudio($meetingModel, $sharedAccess, null, $debug, $dbg);
+                        $fallback = $this->resolveLegacyAudio($meetingModel, $sharedAccess, $sharedMeeting, $debug, $dbg);
                         if ($fallback instanceof \Illuminate\Http\JsonResponse || $fallback instanceof \Illuminate\Http\RedirectResponse || $fallback instanceof \Symfony\Component\HttpFoundation\Response) {
                             return $fallback;
                         }
@@ -2224,7 +2224,7 @@ class MeetingController extends Controller
                         'audio_path' => $audioPath,
                     ]);
 
-                    $fallback = $this->resolveLegacyAudio($meetingModel, $sharedAccess, null, $debug, $dbg);
+                    $fallback = $this->resolveLegacyAudio($meetingModel, $sharedAccess, $sharedMeeting, $debug, $dbg);
                     if ($fallback instanceof \Illuminate\Http\JsonResponse || $fallback instanceof \Illuminate\Http\RedirectResponse || $fallback instanceof \Symfony\Component\HttpFoundation\Response) {
                         return $fallback;
                     }
@@ -2276,7 +2276,7 @@ class MeetingController extends Controller
             try {
                 $legacyModel = TranscriptionLaravel::find($meeting);
                 if ($legacyModel) {
-                    $fallback = $this->resolveLegacyAudio($legacyModel, false, null, request()->query('debug') !== null, $dbg = [], true);
+                    $fallback = $this->resolveLegacyAudio($legacyModel, false, $sharedMeeting, request()->query('debug') !== null, $dbg = [], true);
                     if ($fallback instanceof \Illuminate\Http\JsonResponse || $fallback instanceof \Illuminate\Http\RedirectResponse || $fallback instanceof \Symfony\Component\HttpFoundation\Response) {
                         return $fallback;
                     }

--- a/tests/Feature/MeetingEndpointsTest.php
+++ b/tests/Feature/MeetingEndpointsTest.php
@@ -304,6 +304,105 @@ test('shared meeting audio endpoint uses service account temporary file when ava
     $response->assertRedirect($expectedUrl);
 });
 
+test('shared meeting audio endpoint falls back to impersonation after initial service account failure', function () {
+    $owner = User::factory()->create(['email' => 'owner@example.com']);
+    $recipient = User::factory()->create();
+
+    GoogleToken::create([
+        'username' => $recipient->username,
+        'access_token' => 'test-access',
+        'refresh_token' => 'test-refresh',
+        'expiry_date' => now()->addDay(),
+    ]);
+
+    $meeting = createLegacyMeeting($owner, [
+        'meeting_name' => 'Service Account Meeting',
+        'audio_drive_id' => 'sa-file-id',
+        'audio_download_url' => '',
+    ]);
+
+    SharedMeeting::create([
+        'meeting_id' => $meeting->id,
+        'shared_by' => $owner->id,
+        'shared_with' => $recipient->id,
+        'status' => 'accepted',
+        'shared_at' => now(),
+    ]);
+
+    app()->instance(GoogleDriveService::class, new class {
+        public function setAccessToken($token) {}
+        public function getClient() { return new class { public function isAccessTokenExpired() { return false; } }; }
+        public function refreshToken($refreshToken) { return ['access_token' => 'new-token', 'expires_in' => 3600]; }
+        public function findAudioInFolder($folderId, $meetingTitle, $meetingId) { return []; }
+        public function downloadFileContent($fileId) { return ''; }
+        public function getFileInfo($fileId) { return new class {
+            public function getParents() { return []; }
+            public function getName() { return 'Parent'; }
+            public function getMimeType() { return 'audio/ogg'; }
+        }; }
+        public function getWebContentLink($fileId) { return null; }
+    });
+
+    $serviceAccount = new class {
+        public ?string $impersonated = null;
+        public int $downloadAttempts = 0;
+
+        public function impersonate($email)
+        {
+            $this->impersonated = $email;
+        }
+
+        public function downloadFile($fileId)
+        {
+            $this->downloadAttempts++;
+
+            if ($this->downloadAttempts === 1) {
+                throw new \Exception('service account download failed');
+            }
+
+            if (!$this->impersonated) {
+                throw new \Exception('impersonation was not triggered');
+            }
+
+            return 'fake audio';
+        }
+
+        public function getClient()
+        {
+            return new class {
+                public function fetchAccessTokenWithAssertion()
+                {
+                    return ['access_token' => 'sa-token'];
+                }
+            };
+        }
+
+        public function getFileInfo($fileId)
+        {
+            return new class {
+                public function getName() { return 'audio'; }
+                public function getMimeType() { return 'audio/ogg'; }
+            };
+        }
+    };
+
+    app()->instance(\App\Services\GoogleServiceAccount::class, $serviceAccount);
+
+    Storage::disk('public')->delete('temp/stream_' . $meeting->id . '.ogg');
+    Storage::disk('public')->makeDirectory('temp');
+
+    $response = $this->actingAs($recipient, 'sanctum')->get('/api/meetings/' . $meeting->id . '/audio');
+
+    $expectedPath = storage_path('app/public/temp/stream_' . $meeting->id . '.ogg');
+    expect(file_exists($expectedPath))->toBeTrue();
+
+    $expectedUrl = asset('storage/temp/stream_' . $meeting->id . '.ogg');
+    $response->assertRedirect($expectedUrl);
+
+    expect($serviceAccount->downloadAttempts)->toBe(2);
+    expect($serviceAccount->impersonated)->toBe('owner@example.com');
+});
+
 
 test('destroy meeting returns 500 when Google Drive deletion fails', function () {
     $user = User::factory()->create(['username' => 'user']);


### PR DESCRIPTION
## Summary
- pass the resolved shared meeting instance into `resolveLegacyAudio` from all `streamAudio` fallback paths
- add a feature test that exercises the service-account failure path and verifies the impersonation retry serves audio

## Testing
- Attempted `composer install` *(fails: GitHub 403 when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68cdd942e8888323ae4df275e2423bc7