### PR TITLE
Fix container meeting modal visibility in organization page

### DIFF
--- a/resources/js/organization.js
+++ b/resources/js/organization.js
@@ -469,6 +469,23 @@ Alpine.data('organizationPage', (initialOrganizations = []) => ({
                     return;
                 }
 
+                const modalEl = document.getElementById('container-meetings-modal');
+                if (modalEl) {
+                    modalEl.classList.remove('hidden');
+                    if (modalEl.style.pointerEvents === 'none') {
+                        modalEl.style.pointerEvents = '';
+                    }
+                    if (modalEl.style.visibility === 'hidden') {
+                        modalEl.style.visibility = '';
+                    }
+                    if (modalEl.style.opacity === '0') {
+                        modalEl.style.opacity = '';
+                    }
+                    if (modalEl.getAttribute('aria-hidden') === 'true') {
+                        modalEl.removeAttribute('aria-hidden');
+                    }
+                }
+
                 this.showContainerMeetingsModal = true;
 
                 if (shouldReload && this.selectedContainer.id) {

--- a/resources/js/reuniones_v2.js
+++ b/resources/js/reuniones_v2.js
@@ -4885,15 +4885,39 @@ async function openContainerMeetingsModal(containerId) {
     await loadContainerMeetings(containerId);
 }
 
-function closeContainerMeetingsModal() {
+function closeContainerMeetingsModal(options = {}) {
     const el = document.getElementById('container-meetings-modal');
     if (!el) return;
-    el.classList.add('hidden');
-    // Ensure it's non-interactive and behind other modals
-    el.setAttribute('aria-hidden', 'true');
-    el.style.pointerEvents = 'none';
-    el.style.visibility = 'hidden';
-    el.style.opacity = '0';
+
+    const hasExplicitOrganizationFlag = typeof options.fromOrganization === 'boolean';
+    const isOrganizationContext = hasExplicitOrganizationFlag
+        ? options.fromOrganization
+        : el.hasAttribute('x-show') || !!document.querySelector('[x-data^="organizationPage" i]');
+
+    if (isOrganizationContext) {
+        // El modal está administrado por Alpine, evitar manipular clases/estilos que interfieran.
+        el.classList.remove('hidden');
+        if (el.getAttribute('aria-hidden') === 'true') {
+            el.removeAttribute('aria-hidden');
+        }
+        if (el.style.pointerEvents === 'none') {
+            el.style.pointerEvents = '';
+        }
+        if (el.style.visibility === 'hidden') {
+            el.style.visibility = '';
+        }
+        if (el.style.opacity === '0') {
+            el.style.opacity = '';
+        }
+    } else {
+        el.classList.add('hidden');
+        // Ensure it's non-interactive and behind other modals (legacy modal)
+        el.setAttribute('aria-hidden', 'true');
+        el.style.pointerEvents = 'none';
+        el.style.visibility = 'hidden';
+        el.style.opacity = '0';
+    }
+
     currentContainerForMeetings = null;
 }
 
@@ -5005,7 +5029,7 @@ function openMeetingModalFromContainer(meetingId) {
     }
 
     // Cerrar el modal del contenedor (fallback para páginas fuera de organización)
-    closeContainerMeetingsModal();
+    closeContainerMeetingsModal({ fromOrganization: !!organizationComponent });
 
     // Abrir el modal de la reunión
     setTimeout(() => {


### PR DESCRIPTION
## Summary
- update closeContainerMeetingsModal to support organization context and avoid forcing hidden styles while keeping legacy fallback
- ensure the organization container meeting modal clears hidden/pointer/visibility/opacity flags before being restored

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cddba4ca048323a998709ca2a83d99