### PR TITLE
Improve global chat search and hide contacts after global chat

### DIFF
--- a/resources/views/chat/index.blade.php
+++ b/resources/views/chat/index.blade.php
@@ -106,7 +106,7 @@
                 </div>
 
                 <!-- Contactos -->
-                <div class="border-t border-slate-700/50">
+                <div id="contacts-section" class="border-t border-slate-700/50">
                     <div class="p-3 flex items-center justify-between">
                         <h3 class="text-sm font-semibold text-slate-300">Contactos</h3>
                         <button id="refresh-contacts" class="text-xs text-slate-400 hover:text-slate-200">Refrescar</button>


### PR DESCRIPTION
## Summary
- normalize and broaden the global user search so it returns matches across the whole directory regardless of casing or spacing
- hide the contact list once a chat is opened from the global search, while keeping the section visible otherwise and allowing refresh to restore it
- expose the contacts section in the Blade view so the frontend code can control its visibility

## Testing
- php artisan test *(fails: missing vendor/autoload.php in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d58f2de38883239198668402d4bf26