### PR TITLE
Handle null container groups in API

### DIFF
--- a/app/Http/Controllers/ContainerController.php
+++ b/app/Http/Controllers/ContainerController.php
@@ -122,7 +122,7 @@ class ContainerController extends Controller
                         'created_at' => $container->created_at->format('d/m/Y H:i'),
                         'meetings_count' => $container->meetingRelations()->count(),
                         'is_company' => $container->group_id !== null,
-                        'group_name' => $container->group->nombre_grupo ?? null,
+                        'group_name' => optional($container->group)->nombre_grupo,
                         'drive_folder_id' => $container->drive_folder_id,
                         'metadata' => $container->metadata,
                     ];

--- a/tests/Feature/ContainerEndpointsTest.php
+++ b/tests/Feature/ContainerEndpointsTest.php
@@ -36,6 +36,23 @@ test('user can create container', function () {
     ]);
 });
 
+test('personal containers are listed with null group name', function () {
+    $user = User::factory()->create(['username' => 'eve']);
+
+    $container = MeetingContentContainer::create([
+        'username' => $user->username,
+        'name' => 'Personal Notes',
+        'is_active' => true,
+    ]);
+
+    $response = $this->actingAs($user, 'sanctum')->getJson('/api/content-containers');
+
+    $response->assertOk()
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('containers.0.id', $container->id)
+        ->assertJsonPath('containers.0.group_name', null);
+});
+
 test('user can add meeting to container and list meetings', function () {
     $user = User::factory()->create(['username' => 'bob']);
 


### PR DESCRIPTION
## Summary
- guard the container->group access in the content container listing so personal containers serialize safely
- add a regression feature test covering personal containers without groups in the API response

## Testing
- php artisan test *(fails: vendor/autoload.php missing; composer install requires GitHub access which returns 403 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b391bbcc8323a82a7c05b096e30b