### PR TITLE
Add artisan command to encrypt legacy Drive tokens

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,9 @@
+# Instrucciones de despliegue
+
+Después de aplicar esta actualización, ejecuta inmediatamente el comando:
+
+```
+php artisan encrypt:drive-tokens
+```
+
+Este paso migra los tokens legacy de Google Drive almacenados en texto plano y garantiza que queden protegidos con los nuevos mutadores. El comando genera un resumen de cuántos registros fueron actualizados, por lo que puede ejecutarse de forma segura más de una vez si es necesario.

--- a/app/Console/Commands/EncryptLegacyDriveTokens.php
+++ b/app/Console/Commands/EncryptLegacyDriveTokens.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\GoogleToken;
+use App\Models\OrganizationGoogleToken;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Log;
+
+class EncryptLegacyDriveTokens extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'encrypt:drive-tokens';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Encrypt legacy Google Drive tokens stored as plain text';
+
+    public function handle(): int
+    {
+        $this->info('Iniciando migración de tokens de Google Drive...');
+
+        $googleTokenUpdates = $this->processGoogleTokens();
+        $organizationTokenUpdates = $this->processOrganizationTokens();
+        $totalUpdates = $googleTokenUpdates + $organizationTokenUpdates;
+
+        $this->info("GoogleToken actualizados: {$googleTokenUpdates}");
+        $this->info("OrganizationGoogleToken actualizados: {$organizationTokenUpdates}");
+        $this->info("Total de registros actualizados: {$totalUpdates}");
+
+        Log::info('encrypt:drive-tokens summary', [
+            'google_tokens_updated' => $googleTokenUpdates,
+            'organization_google_tokens_updated' => $organizationTokenUpdates,
+            'total_updated' => $totalUpdates,
+        ]);
+
+        $this->info('Migración finalizada.');
+
+        return self::SUCCESS;
+    }
+
+    private function processGoogleTokens(): int
+    {
+        $updates = 0;
+
+        GoogleToken::query()->chunkById(100, function ($tokens) use (&$updates) {
+            foreach ($tokens as $token) {
+                if ($this->encryptModelAttributes($token, [
+                    'access_token',
+                    'refresh_token',
+                    'recordings_folder_id',
+                ])) {
+                    $token->save();
+                    $updates++;
+                }
+            }
+        });
+
+        return $updates;
+    }
+
+    private function processOrganizationTokens(): int
+    {
+        $updates = 0;
+
+        OrganizationGoogleToken::query()->chunkById(100, function ($tokens) use (&$updates) {
+            foreach ($tokens as $token) {
+                if ($this->encryptModelAttributes($token, [
+                    'access_token',
+                    'refresh_token',
+                ])) {
+                    $token->save();
+                    $updates++;
+                }
+            }
+        });
+
+        return $updates;
+    }
+
+    private function encryptModelAttributes(Model $model, array $attributes): bool
+    {
+        $updated = false;
+
+        foreach ($attributes as $attribute) {
+            $rawValue = $model->getRawOriginal($attribute);
+
+            if ($rawValue === null) {
+                continue;
+            }
+
+            try {
+                Crypt::decryptString($rawValue);
+            } catch (DecryptException $exception) {
+                $value = $model->getAttribute($attribute);
+                $model->setAttribute($attribute, $value);
+                $updated = true;
+            }
+        }
+
+        return $updated;
+    }
+}

--- a/tests/Feature/Commands/EncryptDriveTokensCommandTest.php
+++ b/tests/Feature/Commands/EncryptDriveTokensCommandTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use App\Models\GoogleToken;
+use App\Models\OrganizationGoogleToken;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+
+it('encrypts legacy drive tokens stored as plain text', function () {
+    $now = now()->toDateTimeString();
+
+    $googleTokenId = DB::table('google_tokens')->insertGetId([
+        'username' => 'legacy@example.com',
+        'access_token' => 'legacy-access-token',
+        'refresh_token' => 'legacy-refresh-token',
+        'expiry_date' => $now,
+        'recordings_folder_id' => 'legacy-folder-id',
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    $organizationId = DB::table('organizations')->insertGetId([
+        'nombre_organizacion' => 'Legacy Org',
+        'descripcion' => null,
+        'imagen' => null,
+        'num_miembros' => 0,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    $legacyOrgAccessToken = [
+        'access_token' => 'org-access-token',
+        'refresh_token' => 'org-refresh-token',
+        'expires_in' => 3600,
+    ];
+
+    DB::table('organization_google_tokens')->insert([
+        'organization_id' => $organizationId,
+        'access_token' => json_encode($legacyOrgAccessToken),
+        'refresh_token' => 'org-plain-refresh',
+        'expiry_date' => $now,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    $exitCode = Artisan::call('encrypt:drive-tokens');
+
+    expect($exitCode)->toBe(0);
+
+    $output = Artisan::output();
+    expect($output)->toContain('GoogleToken actualizados: 1');
+    expect($output)->toContain('OrganizationGoogleToken actualizados: 1');
+    expect($output)->toContain('Total de registros actualizados: 2');
+
+    $googleToken = GoogleToken::findOrFail($googleTokenId);
+
+    expect(Crypt::decryptString($googleToken->getRawOriginal('access_token')))->toBe('legacy-access-token');
+    expect(Crypt::decryptString($googleToken->getRawOriginal('refresh_token')))->toBe('legacy-refresh-token');
+    expect(Crypt::decryptString($googleToken->getRawOriginal('recordings_folder_id')))->toBe('legacy-folder-id');
+
+    expect($googleToken->access_token)->toBe('legacy-access-token');
+    expect($googleToken->refresh_token)->toBe('legacy-refresh-token');
+    expect($googleToken->recordings_folder_id)->toBe('legacy-folder-id');
+
+    $organizationToken = OrganizationGoogleToken::where('organization_id', $organizationId)->firstOrFail();
+
+    expect(Crypt::decryptString($organizationToken->getRawOriginal('access_token')))->toBe(json_encode($legacyOrgAccessToken));
+    expect(Crypt::decryptString($organizationToken->getRawOriginal('refresh_token')))->toBe('org-plain-refresh');
+
+    $decodedAccessToken = $organizationToken->access_token;
+    expect($decodedAccessToken)->toBeArray();
+    expect($decodedAccessToken['access_token'])->toBe('org-access-token');
+    expect($decodedAccessToken['refresh_token'])->toBe('org-refresh-token');
+
+    expect($organizationToken->refresh_token)->toBe('org-plain-refresh');
+});


### PR DESCRIPTION
## Summary
- add an `encrypt:drive-tokens` artisan command that reprocesses legacy GoogleToken and OrganizationGoogleToken records and logs how many entries were re-encrypted
- ensure plain-text recordings folder IDs are re-encrypted and covered by a feature test that verifies the new command
- document the post-deploy step to run the command after releasing the update

## Testing
- ⚠️ `php artisan test` *(fails: composer install requires GitHub authentication because external downloads are blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b310ae3c832393a9cc29813963b7