### PR TITLE
Enhance group documents aggregation with container details

### DIFF
--- a/resources/views/organization/index.blade.php
+++ b/resources/views/organization/index.blade.php
@@ -606,41 +606,145 @@
                             <div x-show="isLoadingGroupDocuments" class="text-sm text-slate-400">Cargando documentos...</div>
                             <div x-show="!isLoadingGroupDocuments && groupDocumentsError" class="text-sm text-red-400" x-text="groupDocumentsError"></div>
 
-                            <!-- List -->
-                            <ul x-show="!isLoadingGroupDocuments && !groupDocumentsError && groupDocuments.length" class="space-y-3">
-                                <template x-for="file in groupDocuments" :key="file.id">
-                                    <li class="bg-slate-800/50 border border-slate-700/60 rounded-lg p-3">
-                                        <div class="flex items-start gap-3">
-                                            <div class="w-10 h-10 rounded-md bg-slate-800 flex items-center justify-center text-slate-300 flex-shrink-0">
-                                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5A3.375 3.375 0 0010.125 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V15.375a1.125 1.125 0 00-1.125-1.125h-5.25" />
-                                                </svg>
-                                            </div>
-                                            <div class="min-w-0 flex-1">
-                                                <a :href="file.webViewLink" target="_blank" rel="noopener" class="text-sm font-semibold text-yellow-400 hover:underline truncate block" x-text="file.name"></a>
-                                                <div class="text-xs text-slate-500 flex items-center gap-2">
-                                                    <span x-text="formatDateTime(file.modifiedTime)"></span>
-                                                    <span>•</span>
-                                                    <span x-text="formatFileSize(file.size)"></span>
+                            <div x-show="!isLoadingGroupDocuments && !groupDocumentsError && hasGroupDocumentsContent" class="space-y-5">
+                                <template x-if="groupDocuments.subfolders && groupDocuments.subfolders.length">
+                                    <div class="space-y-2">
+                                        <h3 class="text-xs font-semibold tracking-wide uppercase text-slate-400">Subcarpetas del grupo</h3>
+                                        <ul class="space-y-2">
+                                            <template x-for="subfolder in groupDocuments.subfolders" :key="subfolder.id">
+                                                <li class="bg-slate-800/40 border border-slate-700/60 rounded-lg p-3">
+                                                    <div class="flex items-center gap-3">
+                                                        <div class="w-10 h-10 rounded-md bg-slate-800 flex items-center justify-center text-slate-300">
+                                                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 6.75A2.25 2.25 0 014.5 4.5h3.879a1.5 1.5 0 011.06.44l1.122 1.12a1.5 1.5 0 001.06.44H19.5A2.25 2.25 0 0121.75 8.25v9a2.25 2.25 0 01-2.25 2.25h-15A2.25 2.25 0 012.25 17.25v-10.5z" />
+                                                            </svg>
+                                                        </div>
+                                                        <div class="min-w-0 flex-1">
+                                                            <a :href="`https://drive.google.com/drive/folders/${subfolder.id}`" target="_blank" rel="noopener" class="text-sm font-semibold text-yellow-400 hover:underline truncate block" x-text="subfolder.name"></a>
+                                                        </div>
+                                                        <div>
+                                                            <a :href="`https://drive.google.com/drive/folders/${subfolder.id}`" target="_blank" rel="noopener" class="px-2 py-1 text-xs bg-slate-800/60 border border-slate-700/50 rounded-md hover:bg-slate-700/60 transition-colors">Abrir</a>
+                                                        </div>
+                                                    </div>
+                                                </li>
+                                            </template>
+                                        </ul>
+                                    </div>
+                                </template>
+
+                                <template x-if="groupDocuments.files && groupDocuments.files.length">
+                                    <div class="space-y-2">
+                                        <h3 class="text-xs font-semibold tracking-wide uppercase text-slate-400">Archivos del grupo</h3>
+                                        <ul class="space-y-3">
+                                            <template x-for="file in groupDocuments.files" :key="file.id">
+                                                <li class="bg-slate-800/50 border border-slate-700/60 rounded-lg p-3">
+                                                    <div class="flex items-start gap-3">
+                                                        <div class="w-10 h-10 rounded-md bg-slate-800 flex items-center justify-center text-slate-300 flex-shrink-0">
+                                                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5A3.375 3.375 0 0010.125 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V15.375a1.125 1.125 0 00-1.125-1.125h-5.25" />
+                                                            </svg>
+                                                        </div>
+                                                        <div class="min-w-0 flex-1">
+                                                            <a :href="file.webViewLink" target="_blank" rel="noopener" class="text-sm font-semibold text-yellow-400 hover:underline truncate block" x-text="file.name"></a>
+                                                            <div class="text-xs text-slate-500 flex items-center gap-2">
+                                                                <span x-text="formatDateTime(file.modifiedTime)"></span>
+                                                                <span>•</span>
+                                                                <span x-text="formatFileSize(file.size)"></span>
+                                                            </div>
+                                                        </div>
+                                                        <div class="flex items-center gap-2">
+                                                            <a :href="file.webViewLink" target="_blank" rel="noopener" class="px-2 py-1 text-xs bg-slate-800/60 border border-slate-700/50 rounded-md hover:bg-slate-700/60 transition-colors">Abrir</a>
+                                                            <a :href="file.webContentLink" target="_blank" rel="noopener" class="px-2 py-1 text-xs bg-slate-800/60 border border-slate-700/50 rounded-md hover:bg-slate-700/60 transition-colors" x-show="file.webContentLink">Descargar</a>
+                                                        </div>
+                                                    </div>
+                                                </li>
+                                            </template>
+                                        </ul>
+                                    </div>
+                                </template>
+
+                                <template x-if="groupDocuments.containers && groupDocuments.containers.length">
+                                    <div class="space-y-4">
+                                        <template x-for="container in groupDocuments.containers" :key="container.id">
+                                            <div class="bg-slate-800/40 border border-slate-700/60 rounded-lg p-4 space-y-3">
+                                                <div class="flex items-start justify-between gap-3">
+                                                    <div class="min-w-0">
+                                                        <h3 class="text-sm font-semibold text-yellow-300" x-text="container.name || 'Contenedor sin nombre'"></h3>
+                                                        <p class="text-xs text-slate-400 mt-1" x-show="container.description" x-text="container.description"></p>
+                                                    </div>
+                                                    <div class="flex items-center gap-2" x-show="container.folder_id">
+                                                        <a :href="`https://drive.google.com/drive/folders/${container.folder_id}`" target="_blank" rel="noopener" class="px-2 py-1 text-xs bg-slate-800/60 border border-slate-700/50 rounded-md hover:bg-slate-700/60 transition-colors">Abrir carpeta</a>
+                                                    </div>
+                                                </div>
+
+                                                <template x-if="container.subfolders && container.subfolders.length">
+                                                    <div class="space-y-2">
+                                                        <h4 class="text-xs font-semibold tracking-wide uppercase text-slate-400">Subcarpetas</h4>
+                                                        <ul class="space-y-2">
+                                                            <template x-for="subfolder in container.subfolders" :key="subfolder.id">
+                                                                <li class="bg-slate-900/40 border border-slate-700/50 rounded-lg p-3 flex items-center justify-between gap-3">
+                                                                    <div class="flex items-center gap-3 min-w-0">
+                                                                        <div class="w-8 h-8 rounded-md bg-slate-800 flex items-center justify-center text-slate-300">
+                                                                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+                                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 6.75A2.25 2.25 0 014.5 4.5h3.879a1.5 1.5 0 011.06.44l1.122 1.12a1.5 1.5 0 001.06.44H19.5A2.25 2.25 0 0121.75 8.25v9a2.25 2.25 0 01-2.25 2.25h-15A2.25 2.25 0 012.25 17.25v-10.5z" />
+                                                                            </svg>
+                                                                        </div>
+                                                                        <a :href="`https://drive.google.com/drive/folders/${subfolder.id}`" target="_blank" rel="noopener" class="text-sm font-medium text-yellow-300 hover:underline truncate block" x-text="subfolder.name"></a>
+                                                                    </div>
+                                                                    <a :href="`https://drive.google.com/drive/folders/${subfolder.id}`" target="_blank" rel="noopener" class="px-2 py-1 text-xs bg-slate-800/60 border border-slate-700/50 rounded-md hover:bg-slate-700/60 transition-colors">Abrir</a>
+                                                                </li>
+                                                            </template>
+                                                        </ul>
+                                                    </div>
+                                                </template>
+
+                                                <template x-if="container.files && container.files.length">
+                                                    <div class="space-y-2">
+                                                        <h4 class="text-xs font-semibold tracking-wide uppercase text-slate-400">Archivos</h4>
+                                                        <ul class="space-y-2">
+                                                            <template x-for="file in container.files" :key="file.id">
+                                                                <li class="bg-slate-900/40 border border-slate-700/50 rounded-lg p-3">
+                                                                    <div class="flex items-start gap-3">
+                                                                        <div class="w-8 h-8 rounded-md bg-slate-800 flex items-center justify-center text-slate-300 flex-shrink-0">
+                                                                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+                                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5A3.375 3.375 0 0010.125 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V15.375a1.125 1.125 0 00-1.125-1.125h-5.25" />
+                                                                            </svg>
+                                                                        </div>
+                                                                        <div class="min-w-0 flex-1">
+                                                                            <a :href="file.webViewLink" target="_blank" rel="noopener" class="text-sm font-medium text-yellow-300 hover:underline truncate block" x-text="file.name"></a>
+                                                                            <div class="text-xs text-slate-500 flex items-center gap-2">
+                                                                                <span x-text="formatDateTime(file.modifiedTime)"></span>
+                                                                                <span>•</span>
+                                                                                <span x-text="formatFileSize(file.size)"></span>
+                                                                            </div>
+                                                                        </div>
+                                                                        <div class="flex items-center gap-2">
+                                                                            <a :href="file.webViewLink" target="_blank" rel="noopener" class="px-2 py-1 text-xs bg-slate-800/60 border border-slate-700/50 rounded-md hover:bg-slate-700/60 transition-colors">Abrir</a>
+                                                                            <a :href="file.webContentLink" target="_blank" rel="noopener" class="px-2 py-1 text-xs bg-slate-800/60 border border-slate-700/50 rounded-md hover:bg-slate-700/60 transition-colors" x-show="file.webContentLink">Descargar</a>
+                                                                        </div>
+                                                                    </div>
+                                                                </li>
+                                                            </template>
+                                                        </ul>
+                                                    </div>
+                                                </template>
+
+                                                <div x-show="(!container.files || !container.files.length) && (!container.subfolders || !container.subfolders.length)" class="text-xs text-slate-500 bg-slate-900/30 border border-slate-700/40 rounded-lg p-3">
+                                                    Este contenedor no tiene documentos ni subcarpetas todavía.
                                                 </div>
                                             </div>
-                                            <div class="flex items-center gap-2">
-                                                <a :href="file.webViewLink" target="_blank" rel="noopener" class="px-2 py-1 text-xs bg-slate-800/60 border border-slate-700/50 rounded-md hover:bg-slate-700/60 transition-colors">Abrir</a>
-                                                <a :href="file.webContentLink" target="_blank" rel="noopener" class="px-2 py-1 text-xs bg-slate-800/60 border border-slate-700/50 rounded-md hover:bg-slate-700/60 transition-colors" x-show="file.webContentLink">Descargar</a>
-                                            </div>
-                                        </div>
-                                    </li>
+                                        </template>
+                                    </div>
                                 </template>
-                            </ul>
+                            </div>
 
-                            <!-- Empty state -->
-                            <div x-show="!isLoadingGroupDocuments && !groupDocumentsError && !groupDocuments.length" class="bg-slate-800/40 border border-slate-700/60 rounded-lg p-6 flex items-center gap-4">
+                            <div x-show="!isLoadingGroupDocuments && !groupDocumentsError && !hasGroupDocumentsContent" class="bg-slate-800/40 border border-slate-700/60 rounded-lg p-6 flex items-center gap-4">
                                 <div class="w-10 h-10 rounded-full bg-slate-800 flex items-center justify-center text-slate-300">
                                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
                                         <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m6-6H6" />
                                     </svg>
                                 </div>
-                                <div class="text-sm text-slate-400" x-text="viewDocumentsContainer ? 'El contenedor no tiene documentos aún.' : 'El grupo no tiene documentos aún.'"></div>
+                                <div class="text-sm text-slate-400" x-text="viewDocumentsContainer ? 'El contenedor no tiene documentos disponibles aún.' : 'Este grupo no tiene documentos ni subcarpetas disponibles.'"></div>
                             </div>
                         </div>
                     </div>

--- a/tests/Feature/OrganizationDocumentsTest.php
+++ b/tests/Feature/OrganizationDocumentsTest.php
@@ -1,0 +1,251 @@
+<?php
+
+use App\Models\Group;
+use App\Models\GroupDriveFolder;
+use App\Models\MeetingContentContainer;
+use App\Models\Organization;
+use App\Models\User;
+use App\Services\GoogleDriveService;
+use App\Services\OrganizationDriveHelper;
+use Google\Service\Drive\DriveFile;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+
+uses(RefreshDatabase::class);
+
+uses()->afterEach(function () {
+    Mockery::close();
+});
+
+test('group documents endpoint returns grouped containers with nested drive data', function () {
+    $user = User::factory()->create(['email' => 'member@example.com']);
+
+    $organization = Organization::create([
+        'nombre_organizacion' => 'Org Demo',
+        'descripcion' => 'Demo',
+        'admin_id' => $user->id,
+    ]);
+
+    $group = Group::create([
+        'id_organizacion' => $organization->id,
+        'nombre_grupo' => 'Equipo Legal',
+        'descripcion' => 'Grupo de prueba',
+    ]);
+
+    DB::table('group_user')->insert([
+        'id_grupo' => $group->id,
+        'user_id' => $user->id,
+        'rol' => 'colaborador',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $containerWithFolder = MeetingContentContainer::create([
+        'name' => 'Carpeta Operativa',
+        'description' => 'Documentos del día a día',
+        'username' => $user->username,
+        'group_id' => $group->id,
+        'drive_folder_id' => 'container-folder-1',
+        'is_active' => true,
+    ]);
+
+    $containerWithoutFolder = MeetingContentContainer::create([
+        'name' => 'Onboarding',
+        'description' => 'Material para nuevas incorporaciones',
+        'username' => $user->username,
+        'group_id' => $group->id,
+        'drive_folder_id' => null,
+        'is_active' => true,
+    ]);
+
+    $inactiveContainer = MeetingContentContainer::create([
+        'name' => 'Archivado',
+        'username' => $user->username,
+        'group_id' => $group->id,
+        'drive_folder_id' => 'container-folder-inactive',
+        'is_active' => false,
+    ]);
+
+    $groupFile = new DriveFile([
+        'id' => 'group-file-1',
+        'name' => 'Plan de trabajo.pdf',
+        'mimeType' => 'application/pdf',
+        'iconLink' => 'https://example.com/icon',
+        'webViewLink' => 'https://drive.test/file/group-file-1',
+        'size' => '1024',
+        'modifiedTime' => '2024-05-01T12:00:00Z',
+        'createdTime' => '2024-05-01T10:00:00Z',
+    ]);
+
+    $groupSubfolder = new DriveFile([
+        'id' => 'group-sub-1',
+        'name' => 'Actas',
+    ]);
+
+    $containerFile = new DriveFile([
+        'id' => 'container-file-1',
+        'name' => 'Contrato marco.docx',
+        'mimeType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'iconLink' => 'https://example.com/icon-doc',
+        'webViewLink' => 'https://drive.test/file/container-file-1',
+        'size' => '2048',
+        'modifiedTime' => '2024-04-20T09:00:00Z',
+        'createdTime' => '2024-04-19T09:00:00Z',
+    ]);
+
+    $containerSubfolder = new DriveFile([
+        'id' => 'container-sub-1',
+        'name' => 'Referencias',
+    ]);
+
+    $driveService = Mockery::mock(GoogleDriveService::class);
+    $driveService->shouldReceive('listFilesInFolder')->with('group-folder-123')->once()->andReturn([$groupFile]);
+    $driveService->shouldReceive('listSubfolders')->with('group-folder-123')->once()->andReturn([$groupSubfolder]);
+    $driveService->shouldReceive('shareItem')->once()->with('group-folder-123', 'member@example.com', 'writer');
+    $driveService->shouldReceive('getWebContentLink')->with('group-file-1')->andReturn('https://download.test/group-file-1');
+    $driveService->shouldReceive('listFilesInFolder')->with('container-folder-1')->once()->andReturn([$containerFile]);
+    $driveService->shouldReceive('listSubfolders')->with('container-folder-1')->once()->andReturn([$containerSubfolder]);
+    $driveService->shouldReceive('getWebContentLink')->with('container-file-1')->andReturn(null);
+    $driveService->shouldReceive('listFilesInFolder')->with('container-folder-2')->once()->andReturn([]);
+    $driveService->shouldReceive('listSubfolders')->with('container-folder-2')->once()->andReturn([]);
+
+    $groupDriveFolder = new GroupDriveFolder();
+    $groupDriveFolder->id = 321;
+    $groupDriveFolder->google_id = 'group-folder-123';
+    $groupDriveFolder->name = 'Equipo Legal';
+
+    $helper = Mockery::mock(OrganizationDriveHelper::class);
+    $helper->shouldReceive('initDrive')->once()->with(Mockery::on(fn($org) => $org->is($organization)))->andReturn(null);
+    $helper->shouldReceive('ensureGroupFolder')->once()->with(Mockery::on(fn($g) => $g->is($group)))->andReturn($groupDriveFolder);
+    $helper->shouldReceive('getDrive')->andReturn($driveService);
+    $helper->shouldReceive('ensureContainerFolder')
+        ->once()
+        ->with(Mockery::on(fn($g) => $g->is($group)), Mockery::on(fn($container) => $container->id === $containerWithoutFolder->id))
+        ->andReturn([
+            'id' => 'container-folder-2',
+            'metadata' => ['name' => 'Onboarding'],
+        ]);
+
+    app()->instance(OrganizationDriveHelper::class, $helper);
+
+    $response = $this->actingAs($user, 'sanctum')
+        ->getJson(route('api.groups.documents.index', ['group' => $group->id]));
+
+    $response->assertOk()
+        ->assertJsonPath('folder.google_id', 'group-folder-123')
+        ->assertJsonPath('permissions.can_manage', true)
+        ->assertJsonPath('files.0.id', 'group-file-1')
+        ->assertJsonPath('subfolders.0.id', 'group-sub-1')
+        ->assertJsonPath('containers.0.id', $containerWithFolder->id)
+        ->assertJsonPath('containers.0.files.0.id', 'container-file-1')
+        ->assertJsonPath('containers.0.subfolders.0.id', 'container-sub-1')
+        ->assertJsonPath('containers.1.id', $containerWithoutFolder->id)
+        ->assertJsonPath('containers.1.folder_id', 'container-folder-2');
+
+    $data = $response->json();
+    $containerIds = collect($data['containers'] ?? [])->pluck('id');
+    expect($containerIds)->toContain($containerWithFolder->id);
+    expect($containerIds)->toContain($containerWithoutFolder->id);
+    expect($containerIds)->not()->toContain($inactiveContainer->id);
+
+    $containerWithoutFolder->refresh();
+    expect($containerWithoutFolder->drive_folder_id)->toBe('container-folder-2');
+});
+
+test('non members cannot view group documents', function () {
+    $owner = User::factory()->create(['email' => 'owner@example.com']);
+    $intruder = User::factory()->create(['email' => 'intruder@example.com']);
+
+    $organization = Organization::create([
+        'nombre_organizacion' => 'Org Privada',
+        'descripcion' => 'Demo',
+        'admin_id' => $owner->id,
+    ]);
+
+    $group = Group::create([
+        'id_organizacion' => $organization->id,
+        'nombre_grupo' => 'Equipo Comercial',
+        'descripcion' => 'Grupo restringido',
+    ]);
+
+    DB::table('group_user')->insert([
+        'id_grupo' => $group->id,
+        'user_id' => $owner->id,
+        'rol' => 'administrador',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $helper = Mockery::mock(OrganizationDriveHelper::class);
+    $helper->shouldReceive('initDrive')->never();
+    app()->instance(OrganizationDriveHelper::class, $helper);
+
+    $response = $this->actingAs($intruder, 'sanctum')
+        ->getJson(route('api.groups.documents.index', ['group' => $group->id]));
+
+    $response->assertForbidden();
+});
+
+test('invited members receive reader permissions when listing group documents', function () {
+    $admin = User::factory()->create(['email' => 'admin@example.com']);
+    $viewer = User::factory()->create(['email' => 'viewer@example.com']);
+
+    $organization = Organization::create([
+        'nombre_organizacion' => 'Org Viewer',
+        'descripcion' => 'Demo',
+        'admin_id' => $admin->id,
+    ]);
+
+    $group = Group::create([
+        'id_organizacion' => $organization->id,
+        'nombre_grupo' => 'Equipo Creativo',
+        'descripcion' => 'Grupo de contenidos',
+    ]);
+
+    DB::table('group_user')->insert([
+        'id_grupo' => $group->id,
+        'user_id' => $viewer->id,
+        'rol' => 'invitado',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $groupFile = new DriveFile([
+        'id' => 'group-file-view',
+        'name' => 'Resumen semanal.pdf',
+        'mimeType' => 'application/pdf',
+        'iconLink' => 'https://example.com/icon-pdf',
+        'webViewLink' => 'https://drive.test/file/group-file-view',
+        'size' => '512',
+        'modifiedTime' => '2024-03-15T12:00:00Z',
+        'createdTime' => '2024-03-15T10:00:00Z',
+    ]);
+
+    $driveService = Mockery::mock(GoogleDriveService::class);
+    $driveService->shouldReceive('listFilesInFolder')->with('group-folder-viewer')->once()->andReturn([$groupFile]);
+    $driveService->shouldReceive('listSubfolders')->with('group-folder-viewer')->once()->andReturn([]);
+    $driveService->shouldReceive('shareItem')->once()->with('group-folder-viewer', 'viewer@example.com', 'reader');
+    $driveService->shouldReceive('getWebContentLink')->with('group-file-view')->andReturn('https://download.test/group-file-view');
+
+    $groupDriveFolder = new GroupDriveFolder();
+    $groupDriveFolder->id = 111;
+    $groupDriveFolder->google_id = 'group-folder-viewer';
+    $groupDriveFolder->name = 'Equipo Creativo';
+
+    $helper = Mockery::mock(OrganizationDriveHelper::class);
+    $helper->shouldReceive('initDrive')->once()->with(Mockery::on(fn($org) => $org->is($organization)))->andReturn(null);
+    $helper->shouldReceive('ensureGroupFolder')->once()->with(Mockery::on(fn($g) => $g->is($group)))->andReturn($groupDriveFolder);
+    $helper->shouldReceive('getDrive')->andReturn($driveService);
+    $helper->shouldReceive('ensureContainerFolder')->never();
+
+    app()->instance(OrganizationDriveHelper::class, $helper);
+
+    $response = $this->actingAs($viewer, 'sanctum')
+        ->getJson(route('api.groups.documents.index', ['group' => $group->id]));
+
+    $response->assertOk()
+        ->assertJsonPath('permissions.can_view', true)
+        ->assertJsonPath('permissions.can_manage', false)
+        ->assertJsonPath('files.0.id', 'group-file-view');
+});


### PR DESCRIPTION
## Summary
- Extend the group documents API to gather active containers, ensuring Drive folders exist, and return nested files and subfolders
- Adapt the organization page store and modal to consume the richer payload, keeping per-section loading and empty states coherent
- Add feature tests covering grouped responses and permission checks for group document listing

## Testing
- php artisan test *(fails: vendor/autoload.php missing because composer install requires GitHub credentials in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b8408f808323810806e22737de79