### PR TITLE
Restrict group documents view button and handle permissions

### DIFF
--- a/resources/views/organization/index.blade.php
+++ b/resources/views/organization/index.blade.php
@@ -374,7 +374,7 @@
                                                 </div>
                                             </div>
                                             <div class="mt-3 flex flex-wrap gap-2">
-                                                <button @click.stop="openViewDocumentsModal(group)" class="px-3 py-1.5 bg-slate-800/70 border border-slate-600/60 text-slate-200 rounded text-xs hover:bg-slate-700/70 transition-colors duration-200">
+                                                <button x-show="canViewGroupDocuments(org, group)" @click.stop="openViewDocumentsModal(group)" class="px-3 py-1.5 bg-slate-800/70 border border-slate-600/60 text-slate-200 rounded text-xs hover:bg-slate-700/70 transition-colors duration-200">
                                                     Ver documentos
                                                 </button>
                                                 <button x-show="canUploadDocuments(org, group)" @click.stop="openUploadDocumentsModal(group)" class="px-3 py-1.5 bg-yellow-500 text-slate-900 rounded text-xs hover:bg-yellow-400 transition-colors duration-200">


### PR DESCRIPTION
## Summary
- hide the group "Ver documentos" action unless the viewer passes new `canViewGroupDocuments` permission checks
- add shared helpers in the organization page script to detect organization/group membership and reuse them in permission logic
- surface permission errors when loading group documents by showing the appropriate message for 403 responses

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5bcaffe988323bf51a25fe1807701