### PR TITLE
Ensure recording limits have defaults in new meeting flow

### DIFF
--- a/resources/js/new-meeting.js
+++ b/resources/js/new-meeting.js
@@ -327,6 +327,7 @@ let PLAN_LIMITS = {
     allow_postpone: true,
     warn_before_minutes: 5,
 };
+let MAX_DURATION_MS = PLAN_LIMITS.max_duration_minutes * 60 * 1000;
 
 
 // ===== FUNCIONES PRINCIPALES =====
@@ -558,6 +559,10 @@ document.addEventListener('DOMContentLoaded', async () => {
                             showPostponeLockedModal();
                         });
                     }
+                }
+                if (limits.allow_postpone) {
+                    postponeToggle.disabled = false;
+                    setPostponeMode(postponeToggle.checked);
                 }
             }
 


### PR DESCRIPTION
## Summary
- initialize the maximum recording duration with a default value before fetching plan limits
- keep using the shared MAX_DURATION_MS variable when applying plan responses
- re-run the postpone toggle logic after successfully loading plan limits so the UI reflects the new state

## Testing
- Manual UI verification (not run; environment lacks browser)


------
https://chatgpt.com/codex/tasks/task_e_68e0e4a786508323a5cac721e22ca6d3