### PR TITLE
Add speaker directory suggestions to audio modals

### DIFF
--- a/resources/css/audio-processing.css
+++ b/resources/css/audio-processing.css
@@ -1558,6 +1558,133 @@ body {
     justify-content: flex-end;
 }
 
+.speaker-suggestions-help {
+    margin-top: 0.5rem;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.speaker-suggestions {
+    margin-top: 0.75rem;
+    background: rgba(15, 23, 42, 0.35);
+    border: 1px solid var(--glass-border);
+    border-radius: 16px;
+    padding: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    max-height: 280px;
+    overflow-y: auto;
+}
+
+.speaker-suggestions::-webkit-scrollbar {
+    width: 6px;
+}
+
+.speaker-suggestions::-webkit-scrollbar-thumb {
+    background: rgba(148, 163, 184, 0.4);
+    border-radius: 9999px;
+}
+
+.speaker-suggestions-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.speaker-suggestions-title {
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-secondary);
+}
+
+.speaker-suggestions-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.speaker-suggestion {
+    background: rgba(59, 130, 246, 0.12);
+    border: 1px solid transparent;
+    color: var(--text-primary);
+    border-radius: 9999px;
+    padding: 0.45rem 0.9rem;
+    font-size: 0.9rem;
+    transition: transform 0.2s ease, background 0.2s ease, border 0.2s ease;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.speaker-suggestion:hover {
+    background: rgba(59, 130, 246, 0.25);
+    border-color: rgba(59, 130, 246, 0.4);
+    transform: translateY(-1px);
+}
+
+.speaker-suggestion:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.4);
+}
+
+.speaker-suggestions-empty {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: flex-start;
+}
+
+.speaker-suggestions-empty-text {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+}
+
+.speaker-suggestions-loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    padding: 1rem 0;
+}
+
+.speaker-suggestions-spinner {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    border: 3px solid rgba(59, 130, 246, 0.2);
+    border-top-color: var(--primary-color);
+    animation: speakerSuggestionsSpin 0.8s linear infinite;
+}
+
+.speaker-suggestions-loading-text {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+@keyframes speakerSuggestionsSpin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+@media (max-width: 640px) {
+    .speaker-suggestions {
+        padding: 0.75rem 0.65rem;
+        gap: 0.75rem;
+    }
+
+    .speaker-suggestion {
+        font-size: 0.85rem;
+        padding: 0.4rem 0.75rem;
+    }
+
+    .speaker-suggestions-title {
+        font-size: 0.8rem;
+    }
+}
+
 .modal-title {
     color: var(--text-primary);
     font-size: 1.5rem;

--- a/resources/views/audio-processing.blade.php
+++ b/resources/views/audio-processing.blade.php
@@ -541,6 +541,8 @@
                     <label class="form-label">Nombre del hablante</label>
                     <input type="text" class="modal-input" id="speaker-name-input" placeholder="Ej: María González">
                     <div class="input-hint">Este cambio solo afectará a este segmento de la transcripción.</div>
+                    <div class="speaker-suggestions-help">Selecciona uno de tus contactos o escribe para buscar más personas.</div>
+                    <div id="speaker-suggestions" class="speaker-suggestions" aria-live="polite"></div>
                 </div>
             </div>
             <div class="modal-footer">
@@ -575,6 +577,8 @@
                     <label class="form-label">Nuevo nombre</label>
                     <input type="text" class="modal-input" id="global-speaker-name-input" placeholder="Ej: María González">
                     <div class="input-hint">Este cambio afectará a todos los segmentos de este hablante.</div>
+                    <div class="speaker-suggestions-help">Comienza a escribir para buscar globalmente o elige de tus contactos.</div>
+                    <div id="global-speaker-suggestions" class="speaker-suggestions" aria-live="polite"></div>
                 </div>
             </div>
             <div class="modal-footer">


### PR DESCRIPTION
## Summary
- add a speaker directory helper that loads contacts and performs global user searches with CSRF headers
- preload and reset suggestion chips when opening or closing individual/global speaker modals
- update modal templates and styles to render responsive suggestion containers with helpful empty states

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0e9c64cac8323b446d99f46862d9e