### PR TITLE
Enable platform user search for assignable users

### DIFF
--- a/docs/tasks-assignable-users.md
+++ b/docs/tasks-assignable-users.md
@@ -1,0 +1,14 @@
+# `/api/tasks-laravel/assignable-users`
+
+Endpoint que devuelve las personas a las que se puede asignar una tarea.
+
+## Parámetros de consulta
+
+- `meeting_id` (opcional): filtra los usuarios que tienen reuniones compartidas con el propietario de la tarea.
+- `query` (opcional, string, máx. 255 caracteres): cuando se incluye se realizan coincidencias parciales por nombre, correo o usuario dentro de la base de datos de usuarios de Juntify. Este parámetro agrega una fuente adicional (`source: "platform"`, `platform: "users"`) a la respuesta.
+
+## Respuesta
+
+La respuesta mantiene la estructura `{ success: true, users: Usuario[] }`. Cada usuario contiene los campos `id`, `name`, `email`, `source` y `platform` (cuando aplica).
+
+Los resultados provenientes de la plataforma están limitados a 10 coincidencias por solicitud para evitar respuestas excesivamente grandes y mantener tiempos de respuesta consistentes.

--- a/resources/js/tests/assignable-users.test.js
+++ b/resources/js/tests/assignable-users.test.js
@@ -7,16 +7,19 @@ test('getSourceLabel returns localized labels for known sources', () => {
     assert.equal(getSourceLabel('contact'), SOURCE_LABELS.contact);
     assert.equal(getSourceLabel('organization'), SOURCE_LABELS.organization);
     assert.equal(getSourceLabel('shared'), SOURCE_LABELS.shared);
+    assert.equal(getSourceLabel('platform'), SOURCE_LABELS.platform);
 });
 
 test('buildOptionLabel includes the category label in the option text', () => {
     const contactOption = buildOptionLabel({ name: 'Ana', source: 'contact' });
     const orgOption = buildOptionLabel({ name: 'Luis', source: 'organization' });
     const sharedOption = buildOptionLabel({ name: 'Marta', source: 'shared' });
+    const platformOption = buildOptionLabel({ name: 'Camila', source: 'platform' });
 
     assert.match(contactOption, /Contacto/);
     assert.match(orgOption, /Organización/);
     assert.match(sharedOption, /Compartidos/);
+    assert.match(platformOption, /Usuarios de Juntify/);
 });
 
 test('groupUsersBySource groups users in the expected categories', () => {
@@ -24,7 +27,8 @@ test('groupUsersBySource groups users in the expected categories', () => {
         { id: 1, source: 'contact' },
         { id: 2, source: 'organization' },
         { id: 3, source: 'shared' },
-        { id: 4, source: 'unknown' },
+        { id: 4, source: 'platform' },
+        { id: 5, source: 'unknown' },
     ];
 
     const grouped = groupUsersBySource(users);
@@ -32,5 +36,6 @@ test('groupUsersBySource groups users in the expected categories', () => {
     assert.equal(grouped.contact.length, 1);
     assert.equal(grouped.organization.length, 1);
     assert.equal(grouped.shared.length, 1);
+    assert.equal(grouped.platform.length, 1);
     assert.equal(grouped.other.length, 1);
 });


### PR DESCRIPTION
## Summary
- add an optional `query` filter to the assignable-users endpoint that searches platform accounts with a capped result set
- normalize assignable user options in the frontend, pass the search term from the task modals, and surface the new source label
- extend automated coverage and document the new API parameter and limits for future integrations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e163705b10832391148d148503bc0c