### PR TITLE
Fix new meeting recording globals initialization

### DIFF
--- a/resources/js/new-meeting.js
+++ b/resources/js/new-meeting.js
@@ -50,6 +50,9 @@ let failedAudioBlob = null; // Almacenar blob que falló al subir
 let failedAudioName = null; // Nombre del archivo que falló
 let retryAttempts = 0; // Contador de intentos de resubida
 const MAX_RETRY_ATTEMPTS = 3; // Máximo número de reintentos
+let recordedChunks = [];
+let currentRecordingId = null;
+let chunkIndex = 0;
 
 // Función para obtener el mejor formato de audio disponible priorizando OGG (Vorbis)
 function getOptimalAudioFormat() {


### PR DESCRIPTION
## Summary
- declare explicit global state for recorded chunk tracking in the new meeting script to avoid implicit globals

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e169d9077c832397eccdcd9c30636c