### PR TITLE
Remove hardcoded spectrogram background colors

### DIFF
--- a/resources/css/new-meeting.css
+++ b/resources/css/new-meeting.css
@@ -1637,7 +1637,6 @@ input#postpone-toggle:checked + .switch-track .switch-label.on  { opacity: 0.95;
 /* Spectrogram */
 .spectrogram-wrap {
     margin-top: 10px;
-    background: rgba(0, 0, 0, 0.2);
     border-radius: 8px;
     overflow: hidden;
 }
@@ -1646,7 +1645,6 @@ input#postpone-toggle:checked + .switch-track .switch-label.on  { opacity: 0.95;
     display: block;
     width: 100%;
     height: 80px;
-    background: #0b1020;
 }
 
 /* Timer de reunión */


### PR DESCRIPTION
## Summary
- remove the dark background color from the spectrogram container and canvas so they inherit the surrounding theme

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e17ce464208323b668eab5f709abed