### PR TITLE
Add FFmpeg-based OGG conversion fallback for recordings

### DIFF
--- a/resources/js/media/ffmpeg.js
+++ b/resources/js/media/ffmpeg.js
@@ -1,0 +1,88 @@
+let ffmpegLoaderPromise = null;
+let ffmpegInstance = null;
+let fetchFileFn = null;
+let ffmpegQueue = Promise.resolve();
+
+async function loadFFmpeg() {
+    if (!ffmpegLoaderPromise) {
+        ffmpegLoaderPromise = (async () => {
+            const [ffmpegModule, coreUrlModule, wasmUrlModule] = await Promise.all([
+                import('@ffmpeg/ffmpeg'),
+                import('@ffmpeg/core?url'),
+                import('@ffmpeg/core/wasm?url')
+            ]);
+            const { createFFmpeg, fetchFile } = ffmpegModule;
+            const ffmpeg = createFFmpeg({
+                log: Boolean(import.meta.env?.DEV)
+            });
+            const coreURL = coreUrlModule?.default || coreUrlModule;
+            const wasmURL = wasmUrlModule?.default || wasmUrlModule;
+            await ffmpeg.load({
+                coreURL,
+                wasmURL
+            });
+            ffmpegInstance = ffmpeg;
+            fetchFileFn = fetchFile;
+            return ffmpegInstance;
+        })();
+    }
+    await ffmpegLoaderPromise;
+    return ffmpegInstance;
+}
+
+async function runSerial(fn) {
+    const job = ffmpegQueue.then(() => fn());
+    ffmpegQueue = job.then(() => undefined, () => undefined);
+    return job;
+}
+
+function getInputFileName(blob) {
+    const type = blob?.type || '';
+    if (type.includes('ogg')) return 'input.ogg';
+    if (type.includes('mpeg')) return 'input.mp3';
+    if (type.includes('webm')) return 'input.webm';
+    if (type.includes('mp4')) return 'input.mp4';
+    if (type.includes('wav')) return 'input.wav';
+    if (type.includes('m4a')) return 'input.m4a';
+    return 'input.bin';
+}
+
+export async function convertBlobToOgg(blob) {
+    if (!blob) {
+        throw new Error('Se requiere un blob válido para convertir con FFmpeg');
+    }
+
+    const ffmpeg = await loadFFmpeg();
+
+    return runSerial(async () => {
+        const inputName = getInputFileName(blob);
+        const outputName = 'output.ogg';
+
+        try {
+            if (!fetchFileFn) {
+                throw new Error('FFmpeg no se inicializó correctamente');
+            }
+
+            const fileData = await fetchFileFn(blob);
+            ffmpeg.FS('writeFile', inputName, fileData);
+
+            await ffmpeg.run(
+                '-i', inputName,
+                '-vn',
+                '-acodec', 'libvorbis',
+                '-f', 'ogg',
+                outputName
+            );
+
+            const outputData = ffmpeg.FS('readFile', outputName);
+            const buffer = outputData.buffer.slice(
+                outputData.byteOffset,
+                outputData.byteOffset + outputData.byteLength
+            );
+            return new Blob([buffer], { type: 'audio/ogg' });
+        } finally {
+            try { ffmpeg.FS('unlink', inputName); } catch (_) {}
+            try { ffmpeg.FS('unlink', outputName); } catch (_) {}
+        }
+    });
+}


### PR DESCRIPTION
## Summary
- add a lazy-loaded FFmpeg helper to transcode recorded blobs into OGG/Vorbis when native support is unavailable
- update the meeting recorder pipeline to invoke the FFmpeg path as needed and ensure audio-only OGG blobs for uploads and downloads

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e180ab28588323a617b6362ec4ade5