### PR TITLE
Remove spectrograms from meeting recorder UI

### DIFF
--- a/resources/css/new-meeting.css
+++ b/resources/css/new-meeting.css
@@ -1521,6 +1521,9 @@ input#postpone-toggle:checked + .switch-track .switch-label.on  { opacity: 0.95;
     border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: 12px;
     padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
 }
 
 .source-header {
@@ -1610,21 +1613,6 @@ input#postpone-toggle:checked + .switch-track .switch-label.on  { opacity: 0.95;
 
 .meeting-audio-bar.high {
     background: linear-gradient(to top, #ef4444, #dc2626);
-}
-
-/* Spectrogram */
-.spectrogram-wrap {
-    margin-top: 10px;
-    background: rgba(0, 0, 0, 0.2);
-    border-radius: 8px;
-    overflow: hidden;
-}
-
-.spectrogram-canvas {
-    display: block;
-    width: 100%;
-    height: 80px;
-    background: #0b1020;
 }
 
 /* Timer de reunión */

--- a/resources/views/partials/new-meeting/_meeting-recorder.blade.php
+++ b/resources/views/partials/new-meeting/_meeting-recorder.blade.php
@@ -36,9 +36,6 @@
                         @endfor
                     </div>
                 </div>
-                <div class="spectrogram-wrap">
-                    <canvas id="system-spectrogram" class="spectrogram-canvas"></canvas>
-                </div>
             </div>
 
             <!-- Audio del micrófono -->
@@ -56,9 +53,6 @@
                             <div class="meeting-audio-bar"></div>
                         @endfor
                     </div>
-                </div>
-                <div class="spectrogram-wrap">
-                    <canvas id="microphone-spectrogram" class="spectrogram-canvas"></canvas>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- remove the spectrogram canvases from the meeting recorder partial so only the bar visualizers remain
- clean up the meeting CSS by deleting unused spectrogram rules and spacing the audio source containers with flex layout
- strip spectrogram logic from the meeting recorder JavaScript and reset the bar visualizers when entering the mode

## Testing
- php artisan serve --host=0.0.0.0 --port=8000 *(fails: vendor autoload missing due to unavailable composer install)*

------
https://chatgpt.com/codex/tasks/task_e_68e210e97270832381a8ac0725af5c1e