### PR TITLE
Align meeting recorder UI with audio recorder layout

### DIFF
--- a/resources/css/new-meeting.css
+++ b/resources/css/new-meeting.css
@@ -1667,41 +1667,54 @@ input#postpone-toggle:checked + .switch-track .switch-label.on  { opacity: 0.95;
 /* Controles de reunión */
 .meeting-controls {
     display: flex;
-    justify-content: center;
-    gap: 1rem;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
 }
 
-.meeting-record-btn {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    font-size: 1.1rem;
-    padding: 1rem 2rem;
-    border-radius: 25px;
-    font-weight: 600;
-    background: linear-gradient(135deg, var(--primary-color) 0%, var(--primary-hover) 100%);
-    box-shadow: 0 4px 15px rgba(59, 130, 246, 0.3);
-    transition: all 0.3s ease;
+#meeting-recorder .microphone-container {
+    margin-bottom: 0;
 }
+
+#meeting-recorder-actions {
+    width: 100%;
+}
+
+#meeting-recorder-actions .icon-btn {
+    min-width: 48px;
+}
+
 .nav-icon.nav-icon-xxl {
-    width: 30px;
-    height: 30px;
+    width: 48px;
+    height: 48px;
     color: #ffffff;
 }
 
-.meeting-record-btn:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(59, 130, 246, 0.4);
+#meeting-pause.icon-btn {
+    background: rgba(245, 158, 11, 0.18);
+    border-color: rgba(245, 158, 11, 0.25);
 }
 
-
-.meeting-record-btn.recording {
-    background: linear-gradient(135deg, #f97316 0%, #ea580c 100%);
-    box-shadow: 0 4px 15px rgba(249, 115, 22, 0.3);
+#meeting-resume.icon-btn {
+    background: rgba(16, 185, 129, 0.18);
+    border-color: rgba(16, 185, 129, 0.25);
 }
 
-.meeting-record-btn.recording:hover {
-    box-shadow: 0 6px 20px rgba(249, 115, 22, 0.4);
+#meeting-discard.icon-btn {
+    background: rgba(239, 68, 68, 0.18);
+    border-color: rgba(239, 68, 68, 0.25);
+}
+
+#meeting-pause.icon-btn:hover {
+    background: rgba(245, 158, 11, 0.3);
+}
+
+#meeting-resume.icon-btn:hover {
+    background: rgba(16, 185, 129, 0.3);
+}
+
+#meeting-discard.icon-btn:hover {
+    background: rgba(239, 68, 68, 0.3);
 }
 
 .btn-icon {

--- a/resources/views/partials/new-meeting/_meeting-recorder.blade.php
+++ b/resources/views/partials/new-meeting/_meeting-recorder.blade.php
@@ -71,26 +71,35 @@
             </div>
 
         <div class="meeting-controls">
-            <button class="icon-btn" id="meeting-record-btn" onclick="toggleMeetingRecording()">
-                <svg class="nav-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M15 10.5l6-4.5v11l-6-4.5M3 6.75A2.25 2.25 0 015.25 4.5h6A2.25 2.25 0 0113.5 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-6A2.25 2.25 0 013 17.25V6.75z" />
-                </svg>
-            </button>
-            <button class="icon-btn" id="meeting-pause" onclick="pauseRecording()" style="display: none;">
-                <svg class="nav-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 5.25v13.5m-7.5-13.5v13.5" />
-                </svg>
-            </button>
-            <button class="icon-btn" id="meeting-resume" onclick="resumeRecording()" style="display: none;">
-                <svg class="nav-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 5.25l13.5 6.75-13.5 6.75V5.25z" />
-                </svg>
-            </button>
-            <button class="icon-btn" id="meeting-discard" onclick="discardRecording()" style="display: none;">
-                <svg class="nav-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-                </svg>
-            </button>
+            <div class="microphone-container">
+                <div class="volume-rings" id="meeting-volume-rings">
+                    <div class="volume-ring ring-1"></div>
+                    <div class="volume-ring ring-2"></div>
+                    <div class="volume-ring ring-3"></div>
+                </div>
+                <button type="button" class="mic-circle" id="meeting-mic-circle" onclick="toggleMeetingRecording()" aria-label="Iniciar o detener grabación de reunión">
+                    <svg class="nav-icon nav-icon-xxl" id="meeting-record-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M15 10.5l6-4.5v11l-6-4.5M3 6.75A2.25 2.25 0 015.25 4.5h6A2.25 2.25 0 0113.5 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-6A2.25 2.25 0 013 17.25V6.75z" />
+                    </svg>
+                </button>
+            </div>
+            <div class="recorder-actions" id="meeting-recorder-actions">
+                <button class="icon-btn" id="meeting-pause" onclick="pauseRecording()" style="display: none;">
+                    <svg class="nav-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 5.25v13.5m-7.5-13.5v13.5" />
+                    </svg>
+                </button>
+                <button class="icon-btn" id="meeting-resume" onclick="resumeRecording()" style="display: none;">
+                    <svg class="nav-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 5.25l13.5 6.75-13.5 6.75V5.25z" />
+                    </svg>
+                </button>
+                <button class="icon-btn" id="meeting-discard" onclick="discardRecording()" style="display: none;">
+                    <svg class="nav-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
         </div>
     </div>
     <p id="max-duration-hint-meeting" class="text-xs text-gray-500 mt-4 text-center">Puedes grabar hasta 2 horas continuas. Se notificará cuando queden 5 min para el límite.</p>


### PR DESCRIPTION
## Summary
- Replace the meeting recorder CTA with the shared microphone container, dedicated volume rings, and recorder action rail
- Tweak the meeting recorder styles to reuse the mic-circle visuals while keeping meeting-specific spacing and action colors
- Update the meeting recorder logic to drive the new elements, including shared volume ring helpers and live animation of the mixed audio levels

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e21101c9448323b749fb19a1dab0aa