### PR TITLE
Enable system audio by default when entering meeting mode

### DIFF
--- a/resources/js/new-meeting.js
+++ b/resources/js/new-meeting.js
@@ -13,7 +13,7 @@ let audioContext = null;
 let analyser = null;
 let dataArray = null;
 let animationId = null;
-let systemAudioEnabled = false;
+let systemAudioEnabled = true;
 let microphoneAudioEnabled = true;
 let systemAudioMuted = false;
 let microphoneAudioMuted = false;
@@ -316,6 +316,10 @@ function selectRecordingMode(mode) {
     });
     document.querySelector(`[data-mode="${mode}"]`).classList.add('active');
     selectedMode = mode;
+
+    if (mode === 'meeting') {
+        syncMeetingSourceButtons();
+    }
 
     // Mostrar la interfaz correspondiente
     showRecordingInterface(mode);
@@ -1824,6 +1828,34 @@ function setupMeetingRecorder() {
             bar.classList.remove('active', 'high');
         });
     });
+
+    syncMeetingSourceButtons();
+}
+
+function syncMeetingSourceButtons() {
+    const systemBtn = document.getElementById('system-audio-btn');
+    const systemText = systemBtn ? systemBtn.querySelector('.source-text') : null;
+    if (systemBtn && systemText) {
+        if (systemAudioEnabled) {
+            systemBtn.classList.add('active');
+            systemText.textContent = 'Sistema activado';
+        } else {
+            systemBtn.classList.remove('active');
+            systemText.textContent = 'Sistema desactivado';
+        }
+    }
+
+    const microphoneBtn = document.getElementById('microphone-audio-btn');
+    const microphoneText = microphoneBtn ? microphoneBtn.querySelector('.source-text') : null;
+    if (microphoneBtn && microphoneText) {
+        if (microphoneAudioEnabled) {
+            microphoneBtn.classList.add('active');
+            microphoneText.textContent = 'Micrófono activado';
+        } else {
+            microphoneBtn.classList.remove('active');
+            microphoneText.textContent = 'Micrófono desactivado';
+        }
+    }
 }
 
 // Aplica estados de mute/enable a las fuentes durante la reunión
@@ -1839,16 +1871,7 @@ function applyMuteStates() {
 // Alternar audio del sistema
 function toggleSystemAudio() {
     systemAudioEnabled = !systemAudioEnabled;
-    const btn = document.getElementById('system-audio-btn');
-    const text = btn.querySelector('.source-text');
-
-    if (systemAudioEnabled) {
-        btn.classList.add('active');
-        text.textContent = 'Sistema activado';
-    } else {
-        btn.classList.remove('active');
-        text.textContent = 'Sistema desactivado';
-    }
+    syncMeetingSourceButtons();
     // Aplicar inmediatamente si estamos grabando reunión
     if (meetingRecording) applyMuteStates();
 }
@@ -1856,16 +1879,7 @@ function toggleSystemAudio() {
 // Alternar audio del micrófono
 function toggleMicrophoneAudio() {
     microphoneAudioEnabled = !microphoneAudioEnabled;
-    const btn = document.getElementById('microphone-audio-btn');
-    const text = btn.querySelector('.source-text');
-
-    if (microphoneAudioEnabled) {
-        btn.classList.add('active');
-        text.textContent = 'Micrófono activado';
-    } else {
-        btn.classList.remove('active');
-        text.textContent = 'Micrófono desactivado';
-    }
+    syncMeetingSourceButtons();
     // Aplicar inmediatamente si estamos grabando reunión
     if (meetingRecording) applyMuteStates();
 }

--- a/resources/views/partials/new-meeting/_meeting-recorder.blade.php
+++ b/resources/views/partials/new-meeting/_meeting-recorder.blade.php
@@ -8,7 +8,7 @@
 
         <!-- Controles de fuentes de audio -->
         <div class="audio-sources-controls">
-            <button class="audio-source-btn system-audio" id="system-audio-btn" onclick="toggleSystemAudio()">
+            <button class="audio-source-btn system-audio active" id="system-audio-btn" onclick="toggleSystemAudio()">
                 <x-icon name="computer" class="source-icon" />
                 <span class="source-text">Sistema activado</span>
             </button>


### PR DESCRIPTION
## Summary
- default the meeting recorder to include system audio when entering the meeting mode
- centralize meeting source button state updates in a helper used during setup and toggles to avoid flicker
- mark the system audio button as active in the meeting recorder partial to match the initial state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e213838f008323a10ef491a9917054