### PR TITLE
Add title and user mappings for pending audio notifications

### DIFF
--- a/app/Http/Controllers/DriveController.php
+++ b/app/Http/Controllers/DriveController.php
@@ -991,9 +991,12 @@ class DriveController extends Controller
             Notification::create([
                 'remitente' => $user->id,
                 'emisor'    => $user->id,
+                'user_id'   => $user->id,
+                'from_user_id' => $user->id,
                 'status'    => 'pending',
                 'message'   => 'Subida iniciada',
                 'type'      => 'audio_upload',
+                'title'     => 'Subida de audio pendiente',
                 'data'      => [
                     'pending_recording_id' => $pending->id,
                     'meeting_name'         => $fileName,


### PR DESCRIPTION
## Summary
- include notification title when creating pending audio upload notifications
- populate user_id and from_user_id to align with the updated notifications schema

## Testing
- unable to run `php artisan test --filter=NotificationsApiTest` (missing vendor dependencies due to Composer GitHub token requirement)


------
https://chatgpt.com/codex/tasks/task_e_68e2706aea908323a4abaab289f6f027