### PR TITLE
Expose chat contacts endpoint through API routes

### DIFF
--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -134,12 +134,22 @@ class ChatController extends Controller
         $contacts = Contact::where('user_id', $userId)
             ->with(['contact:id,full_name,email'])
             ->get()
-            ->map(fn($c) => [
-                'id' => $c->contact->id,
-                'name' => $c->contact->full_name,
-                'email' => $c->contact->email,
-                'avatar' => strtoupper(substr($c->contact->full_name,0,1))
-            ]);
+            ->map(function ($c) {
+                $contact = $c->contact;
+                if (!$contact) {
+                    return null;
+                }
+
+                return [
+                    'id' => $contact->id,
+                    'name' => $contact->full_name,
+                    'email' => $contact->email,
+                    'avatar' => strtoupper(substr($contact->full_name, 0, 1)),
+                ];
+            })
+            ->filter()
+            ->values();
+
         return response()->json($contacts);
     }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -319,6 +319,7 @@ Route::middleware(['web', 'auth'])->group(function () {
           Route::post('/users/search', [ContactController::class, 'searchUsers'])->name('api.users.search');
 
           Route::get('/chats/test', [ChatController::class, 'apiTest'])->name('api.chats.test');
+          Route::get('/chats/contacts', [ChatController::class, 'contacts'])->name('api.chats.contacts');
           Route::get('/chats', [ChatController::class, 'apiIndex'])->name('api.chats.index');
           Route::post('/chats/create-or-find', [ChatController::class, 'createOrFind'])->name('api.chats.create-or-find');
           Route::post('/chats/unread-count', [ChatController::class, 'getUnreadCount'])->name('api.chats.unread-count');

--- a/routes/web.php
+++ b/routes/web.php
@@ -87,7 +87,6 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/chats/{chat}', [ChatController::class, 'showView'])->name('chats.show');
     // API chat endpoints
     Route::get('/api/chats', [ChatController::class, 'apiIndex'])->name('api.chats.index');
-    Route::get('/api/chats/contacts', [ChatController::class, 'contacts'])->name('api.chats.contacts');
     Route::get('/api/chats/{chat}/messages', [ChatController::class, 'show'])->name('api.chats.messages');
     Route::post('/api/chats/{chat}/messages', [ChatController::class, 'store'])->name('api.chats.messages.store');
     Route::post('/api/chats/create-or-find', [ChatController::class, 'createOrFind'])->name('api.chats.create');


### PR DESCRIPTION
## Summary
- move the chat contacts endpoint from the web routes into the authenticated API route group so it is available under /api/chats/contacts
- harden ChatController::contacts to skip orphaned contact records instead of erroring when relations are missing

## Testing
- not run (vendor directory is not installed in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e357800ddc8323b952b8249a64ce1b