### PR TITLE
Allow sending contact requests by username

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -283,16 +283,25 @@ class ContactController extends Controller
 
         $data = $request->validate([
             'email' => 'nullable|email',
+            'username' => 'nullable|string',
         ]);
 
-        if (empty($data['email'])) {
+        if (empty($data['email']) && empty($data['username'])) {
             return response()->json([
                 'success' => false,
-                'message' => 'Debe proporcionar un correo electrónico.'
+                'message' => 'Debe proporcionar un correo electrónico o nombre de usuario.'
             ], 422);
         }
 
-        $contactUser = User::where('email', $data['email'])->first();
+        $contactUser = null;
+
+        if (! empty($data['email'])) {
+            $contactUser = User::where('email', $data['email'])->first();
+        }
+
+        if (! $contactUser && ! empty($data['username'])) {
+            $contactUser = User::where('username', $data['username'])->first();
+        }
 
         if (! $contactUser) {
             return response()->json([


### PR DESCRIPTION
## Summary
- allow the contact request endpoint to accept either an email address or a username
- update validation to search by username when an email is not provided

## Testing
- not run (composer install requires downloading dependencies from GitHub, which is blocked in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e35c0c169c83239a37f46a2524e5bf