### PR TITLE
Hide chat entry points in navigation and contacts view

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -20,7 +20,9 @@ class ContactController extends Controller
      */
     public function index(): View
     {
-        return view('contacts.index');
+        return view('contacts.index', [
+            'hideChat' => true,
+        ]);
     }
 
     /**

--- a/resources/js/reuniones_v2.js
+++ b/resources/js/reuniones_v2.js
@@ -20,6 +20,13 @@ if (typeof contactsFeatures.showChat === 'undefined') {
 window.contactsFeatures = contactsFeatures;
 
 function isChatEnabled() {
+    const contactsRoot = document.querySelector('[data-contacts-root]');
+    if (contactsRoot) {
+        const showChat = contactsRoot.dataset.showChat;
+        if (typeof showChat !== 'undefined') {
+            return showChat !== 'false';
+        }
+    }
     return Boolean(window.contactsFeatures && window.contactsFeatures.showChat);
 }
 

--- a/resources/views/contacts/index.blade.php
+++ b/resources/views/contacts/index.blade.php
@@ -1,6 +1,6 @@
 @php($hideChat = $hideChat ?? false)
 
-<div class="space-y-6">
+<div class="space-y-6" data-contacts-root data-show-chat="{{ $hideChat ? 'false' : 'true' }}">
     <!-- Header con título y botón de agregar -->
     <div class="flex justify-between items-center">
         <h1 class="text-2xl font-bold text-slate-200">Mis contactos</h1>

--- a/resources/views/partials/navbar.blade.php
+++ b/resources/views/partials/navbar.blade.php
@@ -49,14 +49,6 @@
       Tareas
     </a>
   </li>
-  <li>
-    <a href="{{ route('chats.index') }}" class="{{ request()->routeIs('chats.*') ? 'active' : '' }}">
-      <svg class="nav-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.418 8-9.899 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.418-8 9.899-8s9.899 3.582 9.899 8z" />
-      </svg>
-      Chat
-    </a>
-  </li>
   @php /* visible for all users */ @endphp
   <li>
     <a href="{{ route('organization.index') }}">


### PR DESCRIPTION
## Summary
- remove the chat link from the primary navigation bar
- disable chat controls in the contacts views by default while keeping layout data consistent
- ensure the contacts controller passes the hide flag so dedicated contact pages also omit chat actions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e35f9e98488323a0ae6e7f727c4f47