### PR TITLE
Add discard confirmation modal and recorder control hints

### DIFF
--- a/resources/js/new-meeting.js
+++ b/resources/js/new-meeting.js
@@ -721,7 +721,7 @@ function resumeRecording() {
 }
 
 // Descartar grabación
-function discardRecording() {
+function performDiscardRecording() {
     const wasMeetingRecording = meetingRecording || lastRecordingContext === 'meeting';
 
     discardRequested = true;
@@ -785,6 +785,33 @@ function discardRecording() {
     updateRecordingUI(false);
     resetAudioVisualizer();
     resetRecordingControls();
+}
+
+function closeDiscardRecordingModal() {
+    const modal = document.getElementById('discard-recording-modal');
+    if (modal) {
+        modal.style.display = 'none';
+    }
+}
+
+function requestDiscardRecording() {
+    const modal = document.getElementById('discard-recording-modal');
+
+    if (!modal) {
+        performDiscardRecording();
+        return;
+    }
+
+    modal.style.display = 'block';
+}
+
+function confirmDiscardRecording() {
+    closeDiscardRecordingModal();
+    performDiscardRecording();
+}
+
+function cancelDiscardRecording() {
+    closeDiscardRecordingModal();
 }
 
 function resetRecordingControls() {
@@ -2341,7 +2368,9 @@ window.removeSelectedFile = removeSelectedFile;
 window.processAudioFile = processAudioFile;
 window.pauseRecording = pauseRecording;
 window.resumeRecording = resumeRecording;
-window.discardRecording = discardRecording;
+window.discardRecording = requestDiscardRecording;
+window.confirmDiscardRecording = confirmDiscardRecording;
+window.cancelDiscardRecording = cancelDiscardRecording;
 window.togglePostponeMode = togglePostponeMode;
 // Funciones del grabador de reuniones que faltaban
 window.toggleSystemAudio = toggleSystemAudio;

--- a/resources/views/partials/new-meeting/_audio-recorder.blade.php
+++ b/resources/views/partials/new-meeting/_audio-recorder.blade.php
@@ -44,6 +44,14 @@
             </svg>
             </button>
         </div>
+        <div class="recorder-action-hints text-xs text-gray-500 mt-3 text-center">
+            <div class="flex justify-center gap-6">
+                <span>Pausa</span>
+                <span>Reanudar</span>
+                <span>Descartar</span>
+            </div>
+            <p class="mt-2">Cuando se detenga la reunión, selecciona nuevamente el ícono de micrófono para detener y procesar el audio.</p>
+        </div>
         <div class="postpone-switch flex flex-col items-center mt-6" id="postpone-switch">
             <span id="postpone-mode-label" class="text-sm mb-1">Modo posponer: Apagado</span>
             <label for="postpone-toggle" class="cursor-pointer select-none">
@@ -74,6 +82,25 @@
         <div class="modal-footer" id="save-modal-footer">
             <button class="btn btn-primary" id="analyze-now-btn">Analizar ahora</button>
             <button class="btn" id="postpone-btn">Posponer</button>
+        </div>
+    </div>
+</div>
+
+<!-- Modal Confirmar Descarte -->
+<div class="modal" id="discard-recording-modal" style="display: none;">
+    <div class="modal-content">
+        <div class="modal-header">
+            <h2 class="modal-title">
+                <x-icon name="x" class="modal-icon" />
+                Descartar grabación
+            </h2>
+        </div>
+        <div class="modal-body">
+            <p>¿Deseas descartar la reunión actual? Si confirmas, la grabación se eliminará y no podrás recuperarla.</p>
+        </div>
+        <div class="modal-footer">
+            <button class="btn" onclick="cancelDiscardRecording()">Continuar grabando</button>
+            <button class="btn btn-danger" onclick="confirmDiscardRecording()">Descartar reunión</button>
         </div>
     </div>
 </div>

--- a/resources/views/partials/new-meeting/_meeting-recorder.blade.php
+++ b/resources/views/partials/new-meeting/_meeting-recorder.blade.php
@@ -94,6 +94,14 @@
                     </svg>
                 </button>
             </div>
+            <div class="recorder-action-hints text-xs text-gray-500 mt-3 text-center">
+                <div class="flex justify-center gap-6">
+                    <span>Pausa</span>
+                    <span>Reanudar</span>
+                    <span>Descartar</span>
+                </div>
+                <p class="mt-2">Cuando se detenga la reunión, selecciona nuevamente el ícono de micrófono para detener y procesar el audio.</p>
+            </div>
         </div>
     </div>
     <p id="max-duration-hint-meeting" class="text-xs text-gray-500 mt-4 text-center">Puedes grabar hasta 2 horas continuas. Se notificará cuando queden 5 min para el límite.</p>


### PR DESCRIPTION
## Summary
- show a confirmation modal before discarding an audio or meeting recording
- ensure the existing discard logic only runs after the user confirms the modal
- add contextual hints below the recorder controls for pausa, reanudar y descartar actions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4222ab1fc832391d3f91810387727