### PR TITLE
Add confirmation modal when navigating away during recording

### DIFF
--- a/resources/views/partials/new-meeting/_audio-recorder.blade.php
+++ b/resources/views/partials/new-meeting/_audio-recorder.blade.php
@@ -104,3 +104,22 @@
         </div>
     </div>
 </div>
+
+<!-- Modal Confirmar cambio de vista durante grabación -->
+<div class="modal" id="recording-navigation-modal" style="display: none;">
+    <div class="modal-content">
+        <div class="modal-header">
+            <h2 class="modal-title">
+                <x-icon name="x" class="modal-icon" />
+                Cambiar de vista
+            </h2>
+        </div>
+        <div class="modal-body">
+            <p>¿Seguro que quieres cambiar de vista? Tu grabación actual se descartará.</p>
+        </div>
+        <div class="modal-footer">
+            <button class="btn" onclick="cancelRecordingNavigationChange()">Seguir grabando</button>
+            <button class="btn btn-danger" onclick="confirmRecordingNavigationChange()">Descartar y salir</button>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add a confirmation modal to warn about losing an active grabación when navigating away from the nueva reunión screen
- hook desktop and mobile navbar links to show the modal and discard the recording if the user confirms

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4355abe8483238265e62b0586560c