### PR TITLE
Center discard modal and clean recorder labels

### DIFF
--- a/resources/js/new-meeting.js
+++ b/resources/js/new-meeting.js
@@ -805,7 +805,7 @@ function requestDiscardRecording() {
         return;
     }
 
-    modal.style.display = 'block';
+    modal.style.display = 'flex';
 }
 
 function confirmDiscardRecording() {
@@ -825,7 +825,7 @@ function showRecordingNavigationModal() {
         return;
     }
 
-    modal.style.display = 'block';
+    modal.style.display = 'flex';
 }
 
 function closeRecordingNavigationModal() {

--- a/resources/views/partials/new-meeting/_audio-recorder.blade.php
+++ b/resources/views/partials/new-meeting/_audio-recorder.blade.php
@@ -45,11 +45,6 @@
             </button>
         </div>
         <div class="recorder-action-hints text-xs text-gray-500 mt-3 text-center">
-            <div class="flex justify-center gap-6">
-                <span>Pausa</span>
-                <span>Reanudar</span>
-                <span>Descartar</span>
-            </div>
             <p class="mt-2">Cuando se detenga la reunión, selecciona nuevamente el ícono de micrófono para detener y procesar el audio.</p>
         </div>
         <div class="postpone-switch flex flex-col items-center mt-6" id="postpone-switch">

--- a/resources/views/partials/new-meeting/_meeting-recorder.blade.php
+++ b/resources/views/partials/new-meeting/_meeting-recorder.blade.php
@@ -95,11 +95,6 @@
                 </button>
             </div>
             <div class="recorder-action-hints text-xs text-gray-500 mt-3 text-center">
-                <div class="flex justify-center gap-6">
-                    <span>Pausa</span>
-                    <span>Reanudar</span>
-                    <span>Descartar</span>
-                </div>
                 <p class="mt-2">Cuando se detenga la reunión, selecciona nuevamente el ícono de micrófono para detener y procesar el audio.</p>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- center the discard-related modals by showing them with flex layout
- remove redundant pause/resume/discard text labels beneath recorder controls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e43873fc2c83239df2fd2d4c900aae