### PR TITLE
Enhance task assignment workflows and Kanban views

### DIFF
--- a/app/Models/TaskLaravel.php
+++ b/app/Models/TaskLaravel.php
@@ -27,6 +27,7 @@ class TaskLaravel extends Model
         'google_event_id',
         'google_calendar_id',
         'calendar_synced_at',
+        'overdue_notified_at',
     ];
 
     protected $casts = [
@@ -38,6 +39,7 @@ class TaskLaravel extends Model
         'assignment_status' => 'string',
         'progreso' => 'integer',
         'calendar_synced_at' => 'datetime',
+        'overdue_notified_at' => 'datetime',
     ];
 
     public function meeting()

--- a/database/migrations/2025_10_20_000000_add_overdue_notified_at_to_tasks_laravel_table.php
+++ b/database/migrations/2025_10_20_000000_add_overdue_notified_at_to_tasks_laravel_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tasks_laravel', function (Blueprint $table) {
+            if (!Schema::hasColumn('tasks_laravel', 'overdue_notified_at')) {
+                $table->timestamp('overdue_notified_at')->nullable()->after('calendar_synced_at');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tasks_laravel', function (Blueprint $table) {
+            if (Schema::hasColumn('tasks_laravel', 'overdue_notified_at')) {
+                $table->dropColumn('overdue_notified_at');
+            }
+        });
+    }
+};

--- a/resources/css/tasks-index.css
+++ b/resources/css/tasks-index.css
@@ -33,3 +33,30 @@
     border-left-color: #ef4444;
     background: rgba(239, 68, 68, 0.1);
 }
+
+.kanban-card {
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.kanban-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 20px -15px rgba(15, 23, 42, 0.8);
+}
+
+.kanban-card-pending {
+    border-color: rgba(250, 204, 21, 0.6) !important;
+}
+
+.kanban-card-overdue {
+    border-color: rgba(239, 68, 68, 0.9) !important;
+    animation: overduePulse 1s ease-in-out infinite alternate;
+}
+
+@keyframes overduePulse {
+    from {
+        box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.35);
+    }
+    to {
+        box-shadow: 0 0 12px 4px rgba(239, 68, 68, 0.1);
+    }
+}

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -54,10 +54,18 @@
         <main class="w-full pt-20 lg:pl-24 lg:pt-24 lg:mt-[130px]">
             <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
 
-                @include('tasks.partials._header') <div class="mt-8 flex flex-col-reverse lg:grid lg:grid-cols-3 lg:gap-8 items-start">
+                @include('tasks.partials._header')
+
+                <div class="mt-6 flex flex-wrap gap-2" role="tablist" aria-label="Vistas de tareas">
+                    <button type="button" data-task-view-btn="todo" class="task-view-tab-btn px-4 py-2 rounded-lg border border-slate-700 bg-slate-800/70 text-sm font-medium text-slate-200 focus:outline-none focus:ring-2 focus:ring-blue-500">Todo</button>
+                    <button type="button" data-task-view-btn="calendario" class="task-view-tab-btn px-4 py-2 rounded-lg border border-slate-700 bg-slate-900/40 text-sm font-medium text-slate-300 focus:outline-none focus:ring-2 focus:ring-blue-500">Calendario</button>
+                    <button type="button" data-task-view-btn="tablero" class="task-view-tab-btn px-4 py-2 rounded-lg border border-slate-700 bg-slate-900/40 text-sm font-medium text-slate-300 focus:outline-none focus:ring-2 focus:ring-blue-500">Tablero</button>
+                </div>
+
+                <div class="mt-8 flex flex-col-reverse lg:grid lg:grid-cols-3 lg:gap-8 items-start">
 
                     <div class="lg:col-span-2 flex flex-col gap-8 w-full mt-8 lg:mt-0">
-                        <div x-data="{ open: window.innerWidth >= 1024 }" class="bg-slate-800/50 border border-slate-700/50 rounded-xl">
+                        <div x-data="{ open: window.innerWidth >= 1024 }" class="bg-slate-800/50 border border-slate-700/50 rounded-xl" data-task-view-targets="todo,calendario">
                             <button @click="open = !open" class="w-full flex justify-between items-center p-4 lg:hidden">
                                 <span class="font-semibold text-lg">Calendario</span>
                                 <svg class="w-6 h-6 transition-transform" :class="{ 'rotate-180': open }" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -68,9 +76,11 @@
                                 @include('tasks.partials._calendar-main')
                             </div>
                         </div>
-                        @include('tasks.partials._tabs-reuniones')
+                        <div data-task-view-targets="todo,calendario">
+                            @include('tasks.partials._tabs-reuniones')
+                        </div>
                         <!-- Kanban simple por reunión -->
-                        <div id="kanban-board" class="bg-slate-800/50 border border-slate-700/50 rounded-xl p-4 hidden">
+                        <div id="kanban-board" class="bg-slate-800/50 border border-slate-700/50 rounded-xl p-4 hidden" data-task-view-targets="todo,tablero" data-task-view-requires-kanban="1">
                             <div class="flex flex-col gap-3">
                                 <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
                                     <div>
@@ -82,7 +92,7 @@
                                         <button type="button" class="kanban-tab-btn px-3 py-1.5 text-sm text-slate-300" data-kanban-tab="summary">Resumen</button>
                                     </div>
                                 </div>
-                                <div id="kanban-board-view" class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                                <div id="kanban-board-view" class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
                                     <div class="kanban-col" data-status="pending">
                                         <div class="px-3 py-2 bg-slate-900/60 rounded border border-slate-700/50 font-medium mb-2">Pendientes</div>
                                         <div class="kanban-list min-h-[200px] p-2 bg-slate-900/30 rounded border border-slate-700/30" ondragover="kanbanAllowDrop(event)" ondrop="kanbanDrop(event, 'pending')"></div>
@@ -95,6 +105,10 @@
                                         <div class="px-3 py-2 bg-slate-900/60 rounded border border-slate-700/50 font-medium mb-2">Completadas</div>
                                         <div class="kanban-list min-h-[200px] p-2 bg-slate-900/30 rounded border border-slate-700/30" ondragover="kanbanAllowDrop(event)" ondrop="kanbanDrop(event, 'completed')"></div>
                                     </div>
+                                    <div class="kanban-col" data-status="overdue">
+                                        <div class="px-3 py-2 bg-slate-900/60 rounded border border-slate-700/50 font-medium mb-2 text-rose-300">Vencidas</div>
+                                        <div class="kanban-list min-h-[200px] p-2 bg-slate-900/30 rounded border border-slate-700/30" ondragover="kanbanAllowDrop(event)" ondrop="kanbanDrop(event, 'overdue')"></div>
+                                    </div>
                                 </div>
                                 <div id="kanban-summary-view" class="hidden">
                                     <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -103,7 +117,7 @@
                                             <ul id="summaryPending" class="mt-2 space-y-1 text-sm text-slate-200"></ul>
                                         </div>
                                         <div class="bg-slate-900/50 border border-slate-700/40 rounded-lg p-3">
-                                            <h4 class="text-xs font-semibold uppercase tracking-wide text-rose-300">Retrasados</h4>
+                                            <h4 class="text-xs font-semibold uppercase tracking-wide text-rose-300">Vencidas</h4>
                                             <ul id="summaryOverdue" class="mt-2 space-y-1 text-sm text-slate-200"></ul>
                                         </div>
                                         <div class="bg-slate-900/50 border border-slate-700/40 rounded-lg p-3">
@@ -116,7 +130,7 @@
                         </div>
                     </div>
 
-                    <aside class="col-span-1 w-full">
+                    <aside class="col-span-1 w-full" data-task-view-targets="todo,calendario">
                         @include('tasks.partials._sidebar-details') <div id="tasks-empty" class="info-card p-6 mt-8 text-center text-slate-300">
                             <div class="text-xl font-semibold mb-2">Tareas de la reunión</div>
                             <div class="text-blue-400">Selecciona una conversación</div>
@@ -149,9 +163,60 @@
         const csrfToken = (window.taskLaravel?.csrf || document.querySelector('meta[name="csrf-token"]').content || '');
         let currentKanbanTab = 'board';
         let currentKanbanTasks = [];
+        let currentTaskMainView = 'todo';
+
+        const kanbanBoardElement = document.getElementById('kanban-board');
+        if (kanbanBoardElement && !kanbanBoardElement.dataset.hasKanban) {
+            kanbanBoardElement.dataset.hasKanban = '0';
+        }
+
+        function kanbanHasData(){
+            const board = document.getElementById('kanban-board');
+            return !!(board && board.dataset.hasKanban === '1');
+        }
+
+        function refreshTaskViewVisibility(){
+            document.querySelectorAll('[data-task-view-targets]').forEach(section => {
+                const views = (section.dataset.taskViewTargets || '')
+                    .split(',')
+                    .map(v => v.trim().toLowerCase())
+                    .filter(Boolean);
+                const matchesView = views.length === 0
+                    || views.includes(currentTaskMainView)
+                    || (views.includes('todo') && currentTaskMainView === 'todo');
+                const requiresKanban = section.dataset.taskViewRequiresKanban === '1';
+                const shouldShow = matchesView && (!requiresKanban || kanbanHasData());
+                section.classList.toggle('hidden', !shouldShow);
+            });
+
+            document.querySelectorAll('[data-task-view-btn]').forEach(btn => {
+                const isActive = btn.dataset.taskViewBtn === currentTaskMainView;
+                if (isActive) {
+                    btn.classList.add('bg-slate-800/70', 'text-slate-200');
+                    btn.classList.remove('bg-slate-900/40', 'text-slate-300');
+                } else {
+                    btn.classList.add('bg-slate-900/40', 'text-slate-300');
+                    btn.classList.remove('bg-slate-800/70', 'text-slate-200');
+                }
+            });
+
+            const board = document.getElementById('kanban-board');
+            if (board) {
+                const visible = kanbanHasData() && (currentTaskMainView === 'todo' || currentTaskMainView === 'tablero');
+                board.classList.toggle('hidden', !visible);
+            }
+        }
+
+        function setTaskMainView(view){
+            currentTaskMainView = ['todo', 'calendario', 'tablero'].includes(view) ? view : 'todo';
+            refreshTaskViewVisibility();
+        }
 
         function showKanban(show){
-            document.getElementById('kanban-board').classList.toggle('hidden', !show);
+            const board = document.getElementById('kanban-board');
+            if (!board) return;
+            board.dataset.hasKanban = show ? '1' : '0';
+            refreshTaskViewVisibility();
         }
 
         function kanbanAllowDrop(ev){ ev.preventDefault(); }
@@ -159,6 +224,20 @@
         async function kanbanDrop(ev, status){
             ev.preventDefault();
             const id = ev.dataTransfer.getData('text/plain');
+            if (!id || status === 'overdue') {
+                return;
+            }
+
+            const task = currentKanbanTasks.find(t => String(t.id) === String(id));
+            if (!task) {
+                return;
+            }
+
+            if (task._overdue && status !== 'completed') {
+                alert('Esta tarea está vencida. El dueño debe reprogramar la fecha antes de continuar.');
+                return;
+            }
+
             const prog = status === 'completed' ? 100 : (status === 'in_progress' ? 50 : 0);
             try {
                 const res = await fetch(new URL(`/api/tasks-laravel/tasks/${id}`, window.location.origin), {
@@ -170,62 +249,91 @@
                     body: JSON.stringify({ progreso: prog })
                 });
                 const data = await res.json();
-                if (data.success) {
-                    await kanbanReload();
+                if (!res.ok || !data.success) {
+                    alert(data.message || 'No se pudo actualizar la tarea');
+                    return;
                 }
+                await kanbanReload();
             } catch (e) {
                 console.error(e);
+                alert('No se pudo actualizar la tarea');
             }
         }
 
         async function kanbanReload(){
-            if (!window.lastSelectedMeetingId) return;
+            if (!window.lastSelectedMeetingId) {
+                currentKanbanTasks = [];
+                showKanban(false);
+                return;
+            }
+
             try {
                 const url = new URL('/api/tasks-laravel/tasks', window.location.origin);
                 url.searchParams.set('meeting_id', window.lastSelectedMeetingId);
                 const res = await fetch(url);
                 const json = await res.json();
-                if (!json.success) return;
+                if (!json.success) {
+                    currentKanbanTasks = [];
+                    showKanban(false);
+                    return;
+                }
 
-                const tasks = json.tasks || [];
-                currentKanbanTasks = tasks;
-                const cols = { pending: [], in_progress: [], completed: [] };
-                const now = new Date();
-                now.setHours(0,0,0,0);
-
-                tasks.forEach(t => {
+                const rawTasks = Array.isArray(json.tasks) ? json.tasks : [];
+                const enrichedTasks = rawTasks.map(t => {
                     const progress = typeof t.progreso === 'number' ? t.progreso : 0;
-                    const due = t.fecha_limite ? new Date(`${t.fecha_limite}T23:59:59`) : null;
-                    const completed = progress >= 100;
-                    const overdue = !completed && due && due < new Date();
-                    const status = completed ? 'completed' : (progress > 0 ? 'in_progress' : 'pending');
-                    cols[status].push({ ...t, _overdue: overdue });
+                    const overdue = t.is_overdue === true
+                        || (!!t.fecha_limite && progress < 100 && new Date(`${t.fecha_limite}T23:59:59`) < new Date());
+                    return { ...t, _progress: progress, _overdue: overdue };
+                });
+
+                currentKanbanTasks = enrichedTasks;
+
+                const cols = { pending: [], in_progress: [], completed: [], overdue: [] };
+
+                enrichedTasks.forEach(t => {
+                    const completed = t._progress >= 100;
+                    const status = t._overdue
+                        ? 'overdue'
+                        : (completed ? 'completed' : (t._progress > 0 ? 'in_progress' : 'pending'));
+                    cols[status].push(t);
                 });
 
                 document.querySelectorAll('#kanban-board .kanban-list').forEach(el => el.innerHTML = '');
+
                 Object.entries(cols).forEach(([st, list]) => {
                     const target = document.querySelector(`#kanban-board .kanban-col[data-status="${st}"] .kanban-list`);
                     if (!target) return;
                     list.forEach(t => {
                         const card = document.createElement('div');
-                        card.className = 'bg-slate-800/60 border border-slate-700 rounded p-2 mb-2 cursor-move transition-colors';
+                        card.className = 'kanban-card bg-slate-800/60 border border-slate-700 rounded p-3 mb-2 transition-colors';
                         if (t.assignment_status === 'pending') {
-                            card.classList.add('border-yellow-500/60');
+                            card.classList.add('kanban-card-pending');
                         }
                         if (t._overdue) {
-                            card.classList.add('border-rose-500/60');
+                            card.classList.add('kanban-card-overdue', 'cursor-not-allowed');
+                            card.draggable = false;
+                            card.setAttribute('aria-disabled', 'true');
+                            card.title = 'Tarea vencida. Espera a que el dueño reprograma la fecha.';
+                        } else {
+                            card.classList.add('cursor-move');
+                            card.draggable = true;
+                            card.setAttribute('aria-disabled', 'false');
                         }
-                        card.draggable = true;
                         card.dataset.id = t.id;
                         card.addEventListener('dragstart', ev => {
                             ev.dataTransfer.setData('text/plain', String(t.id));
                         });
                         const assigneeName = (t.assigned_user && t.assigned_user.name) || t.asignado || 'Sin asignar';
                         const assignmentText = assignmentStatusLabel(t.assignment_status, !!t.assigned_user_id);
+                        const dueLabel = t.fecha_limite ? `Vence: ${escapeHtml(t.fecha_limite)}` : 'Sin fecha límite';
                         card.innerHTML = `
-                            <div class="text-sm text-slate-200 font-medium">${escapeHtml(t.tarea || 'Sin nombre')}</div>
-                            <div class="text-[11px] text-slate-400 flex justify-between gap-2"><span>${escapeHtml(t.prioridad || '-')} • ${pct(t.progreso)}%</span><span>${assignmentText}</span></div>
+                            <div class="text-sm text-slate-200 font-semibold">${escapeHtml(t.tarea || 'Sin nombre')}</div>
+                            <div class="text-[11px] text-slate-400 flex justify-between gap-2">
+                                <span>${escapeHtml(t.prioridad || '-')} • ${pct(t._progress)}%</span>
+                                <span>${assignmentText}</span>
+                            </div>
                             <div class="text-[11px] text-slate-400">Responsable: ${escapeHtml(assigneeName)}</div>
+                            <div class="text-[11px] text-slate-500">${dueLabel}</div>
                             <div class="text-[11px] text-slate-500">Reunión: ${escapeHtml(t.meeting_name || 'Sin reunión')}</div>
                         `;
                         card.addEventListener('dblclick', () => {
@@ -235,11 +343,13 @@
                     });
                 });
 
-                updateKanbanSummary(tasks);
+                updateKanbanSummary(enrichedTasks);
                 setKanbanTab(currentKanbanTab);
-                showKanban(true);
+                showKanban(enrichedTasks.length > 0);
             } catch (e) {
                 console.error('kanban reload', e);
+                currentKanbanTasks = [];
+                showKanban(false);
             }
         }
 
@@ -272,10 +382,10 @@
             };
 
             tasks.forEach(t => {
-                const progress = typeof t.progreso === 'number' ? t.progreso : 0;
+                const progress = typeof t._progress === 'number' ? t._progress : (typeof t.progreso === 'number' ? t.progreso : 0);
                 const due = t.fecha_limite ? new Date(`${t.fecha_limite}T23:59:59`) : null;
                 const completed = progress >= 100;
-                const overdue = !completed && due && due < today;
+                const overdue = t._overdue || t.is_overdue === true || (!completed && due && due < today);
                 const pending = !completed && !overdue && progress <= 0;
                 const name = (t.assigned_user && t.assigned_user.name) || t.asignado || 'Sin asignar';
                 const key = `${t.assigned_user_id || 'none'}::${name}`;
@@ -297,7 +407,7 @@
             });
 
             renderSummaryList(pendingContainer, categories.pending, 'Sin pendientes');
-            renderSummaryList(overdueContainer, categories.overdue, 'Sin atrasos');
+            renderSummaryList(overdueContainer, categories.overdue, 'Sin vencidas');
             renderSummaryList(completedContainer, categories.completed, 'Sin completadas');
         }
 
@@ -338,6 +448,12 @@
         document.querySelectorAll('#kanban-board [data-kanban-tab]').forEach(btn => {
             btn.addEventListener('click', () => setKanbanTab(btn.dataset.kanbanTab));
         });
+
+        document.querySelectorAll('[data-task-view-btn]').forEach(btn => {
+            btn.addEventListener('click', () => setTaskMainView(btn.dataset.taskViewBtn));
+        });
+
+        setTaskMainView('todo');
 
         const _origLoadTasks = window.loadTasksForMeeting;
         window.loadTasksForMeeting = async function(id, src){


### PR DESCRIPTION
## Summary
- add overdue task detection with owner notifications and prevent assignees from moving past-due cards without completion or new dates
- expand task index with Todo/Calendario/Tablero tabs, a fourth “Vencidas” Kanban column, and refreshed card styling/behaviour
- enable searching the global user directory when assigning tasks via new datalist suggestions

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e44352dd7c8323a34a7d55f836571f