### PR TITLE
Expand kanban board width in tasks view

### DIFF
--- a/resources/css/tasks-index.css
+++ b/resources/css/tasks-index.css
@@ -73,3 +73,9 @@
         box-shadow: 0 0 12px 4px rgba(239, 68, 68, 0.1);
     }
 }
+
+@media (min-width: 1024px) {
+    #tasks-layout.kanban-active #tasks-main-column {
+        grid-column: span 3 / span 3;
+    }
+}

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -61,9 +61,9 @@
                     <button type="button" data-task-view-btn="tablero" class="task-view-tab-btn px-4 py-2 rounded-lg border border-slate-700 bg-slate-900/40 text-sm font-medium text-slate-300 focus:outline-none focus:ring-2 focus:ring-blue-500">Tablero</button>
                 </div>
 
-                <div class="mt-8 flex flex-col-reverse lg:grid lg:grid-cols-3 lg:gap-8 items-start">
+                <div id="tasks-layout" class="mt-8 flex flex-col-reverse lg:grid lg:grid-cols-3 lg:gap-8 items-start">
 
-                    <div class="lg:col-span-2 flex flex-col gap-8 w-full mt-8 lg:mt-0">
+                    <div id="tasks-main-column" class="lg:col-span-2 flex flex-col gap-8 w-full mt-8 lg:mt-0">
                         <div x-data="{ open: window.innerWidth >= 1024 }" class="bg-slate-800/50 border border-slate-700/50 rounded-xl" data-task-view-targets="calendario">
                             <button @click="open = !open" class="w-full flex justify-between items-center p-4 lg:hidden">
                                 <span class="font-semibold text-lg">Calendario</span>
@@ -258,6 +258,11 @@
                     btn.classList.remove('bg-slate-800/70', 'text-slate-200');
                 }
             });
+
+            const layout = document.getElementById('tasks-layout');
+            if (layout) {
+                layout.classList.toggle('kanban-active', currentTaskMainView === 'tablero');
+            }
 
             const board = document.getElementById('kanban-board');
             if (board) {


### PR DESCRIPTION
## Summary
- allow the main tasks column to identify the layout container so it can react to the kanban view
- toggle a layout class when the kanban tab is active so the board spans the full grid width
- add CSS to expand the kanban column across all grid columns on large screens

## Testing
- not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e571b504008323b8d546fd209aaef4