### PR TITLE
Add API integration dashboard and token authentication

### DIFF
--- a/app/Http/Controllers/Api/IntegrationAuthController.php
+++ b/app/Http/Controllers/Api/IntegrationAuthController.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\ApiToken;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
+
+class IntegrationAuthController extends Controller
+{
+    public function login(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'email' => 'required_without:username|nullable|email',
+            'username' => 'required_without:email|nullable|string',
+            'password' => 'required|string|min:6',
+            'device_name' => 'nullable|string|max:255',
+        ]);
+
+        $user = null;
+
+        if (!empty($validated['email'])) {
+            $user = User::where('email', $validated['email'])->first();
+        } elseif (!empty($validated['username'])) {
+            $user = User::where('username', $validated['username'])->first();
+        }
+
+        if (!$user || !Hash::check($validated['password'], $user->password)) {
+            throw ValidationException::withMessages([
+                'email' => ['Las credenciales proporcionadas no son válidas.'],
+            ]);
+        }
+
+        do {
+            $plainToken = ApiToken::generatePlainTextToken();
+            $tokenHash = ApiToken::hashToken($plainToken);
+        } while (ApiToken::where('token_hash', $tokenHash)->exists());
+
+        $token = $user->apiTokens()->create([
+            'name' => $validated['device_name'] ?? 'Panel de integraciones',
+            'token_hash' => $tokenHash,
+            'abilities' => [
+                'meetings:read',
+                'tasks:read',
+                'users:search',
+            ],
+            'last_used_at' => now(),
+        ]);
+
+        return response()->json([
+            'token' => $plainToken,
+            'token_type' => 'Bearer',
+            'abilities' => $token->abilities,
+            'created_at' => $token->created_at?->toIso8601String(),
+            'user' => [
+                'id' => $user->id,
+                'username' => $user->username,
+                'full_name' => $user->full_name,
+                'email' => $user->email,
+                'role' => $user->roles,
+            ],
+        ], 201);
+    }
+
+    public function me(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        return response()->json([
+            'id' => $user->id,
+            'username' => $user->username,
+            'full_name' => $user->full_name,
+            'email' => $user->email,
+            'role' => $user->roles,
+        ]);
+    }
+
+    public function logout(Request $request): JsonResponse
+    {
+        $token = $request->attributes->get('apiToken');
+
+        if ($token) {
+            $token->delete();
+        }
+
+        return response()->json([
+            'message' => 'Token de acceso revocado correctamente.',
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/IntegrationDataController.php
+++ b/app/Http/Controllers/Api/IntegrationDataController.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\TaskLaravel;
+use App\Models\TranscriptionLaravel;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class IntegrationDataController extends Controller
+{
+    public function meetings(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        $meetings = TranscriptionLaravel::query()
+            ->where('username', $user->username)
+            ->latest('created_at')
+            ->limit(25)
+            ->get(['id', 'meeting_name', 'created_at']);
+
+        return response()->json([
+            'data' => $meetings->map(fn ($meeting) => [
+                'id' => $meeting->id,
+                'title' => $meeting->meeting_name,
+                'created_at' => $meeting->created_at?->toIso8601String(),
+                'created_at_readable' => $meeting->created_at?->format('d/m/Y H:i'),
+            ])->values(),
+        ]);
+    }
+
+    public function tasks(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $meetingId = $request->query('meeting_id');
+
+        $tasksQuery = TaskLaravel::query()
+            ->with(['meeting:id,meeting_name,created_at'])
+            ->where(function ($query) use ($user) {
+                $query->where('username', $user->username)
+                    ->orWhere('assigned_user_id', $user->id);
+            });
+
+        if ($meetingId) {
+            $tasksQuery->where('meeting_id', $meetingId);
+        }
+
+        $tasks = $tasksQuery
+            ->latest('updated_at')
+            ->limit(50)
+            ->get();
+
+        return response()->json([
+            'data' => $tasks->map(fn ($task) => [
+                'id' => $task->id,
+                'title' => $task->tarea,
+                'status' => $task->assignment_status ?? 'pendiente',
+                'progress' => $task->progreso,
+                'starts_at' => $task->fecha_inicio?->toDateString(),
+                'due_date' => $task->fecha_limite?->toDateString(),
+                'due_time' => $task->hora_limite,
+                'assigned_to' => $task->asignado,
+                'meeting' => $task->meeting ? [
+                    'id' => $task->meeting->id,
+                    'title' => $task->meeting->meeting_name,
+                    'date' => $task->meeting->created_at?->toIso8601String(),
+                ] : null,
+            ])->values(),
+        ]);
+    }
+
+    public function meetingTasks(Request $request, string $meetingId): JsonResponse
+    {
+        $user = $request->user();
+
+        $meeting = TranscriptionLaravel::query()
+            ->where('username', $user->username)
+            ->where('id', $meetingId)
+            ->first();
+
+        if (!$meeting) {
+            return response()->json([
+                'message' => 'Reunión no encontrada o sin permisos para consultarla.',
+            ], 404);
+        }
+
+        $tasks = TaskLaravel::query()
+            ->where('meeting_id', $meeting->id)
+            ->get();
+
+        return response()->json([
+            'meeting' => [
+                'id' => $meeting->id,
+                'title' => $meeting->meeting_name,
+                'created_at' => $meeting->created_at?->toIso8601String(),
+            ],
+            'tasks' => $tasks->map(fn ($task) => [
+                'id' => $task->id,
+                'title' => $task->tarea,
+                'status' => $task->assignment_status ?? 'pendiente',
+                'progress' => $task->progreso,
+                'due_date' => $task->fecha_limite?->toDateString(),
+                'due_time' => $task->hora_limite,
+            ])->values(),
+        ]);
+    }
+
+    public function searchUsers(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'query' => 'required|string|min:2|max:255',
+        ]);
+
+        $term = $validated['query'];
+
+        $users = User::query()
+            ->where(function ($query) use ($term) {
+                $likeTerm = '%' . $term . '%';
+
+                $query->where('full_name', 'like', $likeTerm)
+                    ->orWhere('email', 'like', $likeTerm)
+                    ->orWhere('username', 'like', $likeTerm);
+            })
+            ->orderBy('full_name')
+            ->limit(10)
+            ->get(['id', 'full_name', 'email', 'username', 'roles']);
+
+        return response()->json([
+            'data' => $users->map(fn ($user) => [
+                'id' => $user->id,
+                'full_name' => $user->full_name,
+                'email' => $user->email,
+                'username' => $user->username,
+                'role' => $user->roles,
+            ])->values(),
+        ]);
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -71,5 +71,6 @@ class Kernel extends HttpKernel
         'google.refresh' => \App\Http\Middleware\RefreshGoogleToken::class,
         'cors.ffmpeg' => \App\Http\Middleware\CrossOriginIsolation::class,
         'upload.max150' => \App\Http\Middleware\EnforceMaxUploadSize150MB::class,
+        'api.token' => \App\Http\Middleware\EnsureApiTokenIsValid::class,
     ];
 }

--- a/app/Http/Middleware/EnsureApiTokenIsValid.php
+++ b/app/Http/Middleware/EnsureApiTokenIsValid.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\ApiToken;
+use Closure;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureApiTokenIsValid
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $plainToken = $this->resolveToken($request);
+
+        if (!$plainToken) {
+            return $this->unauthorizedResponse('Se requiere un token de acceso válido.');
+        }
+
+        $token = ApiToken::with('user')
+            ->where('token_hash', ApiToken::hashToken($plainToken))
+            ->first();
+
+        if (!$token || !$token->user) {
+            return $this->unauthorizedResponse('El token proporcionado no es válido.');
+        }
+
+        if ($token->expires_at && $token->expires_at->isPast()) {
+            $token->delete();
+
+            return $this->unauthorizedResponse('El token ha expirado, genera uno nuevo.');
+        }
+
+        if (!$request->user()) {
+            Auth::setUser($token->user);
+        }
+
+        $request->setUserResolver(static fn () => $token->user);
+        $request->attributes->set('apiToken', $token);
+
+        $token->forceFill(['last_used_at' => now()])->save();
+
+        return $next($request);
+    }
+
+    protected function resolveToken(Request $request): ?string
+    {
+        if ($token = $request->bearerToken()) {
+            return $token;
+        }
+
+        if ($headerToken = $request->header('X-API-Token')) {
+            return trim($headerToken);
+        }
+
+        $queryToken = $request->query('api_token');
+
+        return $queryToken ? trim($queryToken) : null;
+    }
+
+    protected function unauthorizedResponse(string $message): JsonResponse
+    {
+        return response()->json([
+            'message' => $message,
+            'code' => 'API_TOKEN_INVALID',
+        ], 401);
+    }
+}

--- a/app/Models/ApiToken.php
+++ b/app/Models/ApiToken.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Str;
+
+class ApiToken extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'name',
+        'token_hash',
+        'abilities',
+        'last_used_at',
+        'expires_at',
+    ];
+
+    protected $casts = [
+        'abilities' => 'array',
+        'last_used_at' => 'datetime',
+        'expires_at' => 'datetime',
+    ];
+
+    public static function hashToken(string $plainToken): string
+    {
+        return hash('sha256', $plainToken);
+    }
+
+    public static function generatePlainTextToken(): string
+    {
+        return Str::random(80);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
 use App\Models\GoogleToken;
+use App\Models\ApiToken;
 
 class User extends Authenticatable
 {
@@ -104,5 +105,10 @@ class User extends Authenticatable
     public function planPurchases(): HasManyThrough
     {
         return $this->hasManyThrough(PlanPurchase::class, UserPlan::class);
+    }
+
+    public function apiTokens(): HasMany
+    {
+        return $this->hasMany(ApiToken::class);
     }
 }

--- a/database/migrations/2024_01_01_000001_create_api_tokens_table.php
+++ b/database/migrations/2024_01_01_000001_create_api_tokens_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('api_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->uuid('user_id');
+            $table->string('name')->nullable();
+            $table->string('token_hash', 64)->unique();
+            $table->json('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('user_id')
+                ->references('id')
+                ->on('users')
+                ->onDelete('cascade');
+
+            $table->index('user_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('api_tokens');
+    }
+};

--- a/resources/css/profile.css
+++ b/resources/css/profile.css
@@ -825,6 +825,326 @@ body {
   box-shadow: 0 15px 40px rgba(239, 68, 68, 0.4);
 }
 
+.api-card {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.api-intro {
+  color: #cbd5e1;
+  line-height: 1.7;
+}
+
+.api-status-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  border-radius: 16px;
+  padding: 1.5rem;
+}
+
+@media (min-width: 1024px) {
+  .api-status-panel {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.api-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.9rem;
+  border-radius: 9999px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  transition: all 0.3s ease;
+}
+
+.api-status--disconnected {
+  background: rgba(148, 163, 184, 0.15);
+  color: #cbd5e1;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+}
+
+.api-status--connected {
+  background: rgba(34, 197, 94, 0.2);
+  color: #22c55e;
+  border: 1px solid rgba(34, 197, 94, 0.45);
+  box-shadow: 0 10px 25px rgba(34, 197, 94, 0.15);
+}
+
+.api-status-help {
+  margin-top: 0.5rem;
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+.api-token-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: rgba(30, 41, 59, 0.6);
+  border-radius: 14px;
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  padding: 1rem 1.25rem;
+}
+
+.api-token-label {
+  font-weight: 600;
+  color: #94a3b8;
+  font-size: 0.85rem;
+}
+
+.api-token-value {
+  font-family: 'Fira Code', 'JetBrains Mono', monospace;
+  font-size: 0.9rem;
+  color: #f8fafc;
+  word-break: break-all;
+}
+
+.api-token-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.api-sections-grid {
+  display: grid;
+  gap: 2rem;
+}
+
+@media (min-width: 1024px) {
+  .api-sections-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.api-section {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  border-radius: 18px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  min-height: 100%;
+}
+
+.api-section h3 {
+  font-size: 1.2rem;
+  color: #e2e8f0;
+}
+
+.api-text {
+  color: #94a3b8;
+  line-height: 1.6;
+}
+
+.api-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.api-form-inline {
+  flex-direction: row;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.api-form .form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 200px;
+  flex: 1;
+}
+
+.api-form label {
+  color: #cbd5e1;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.api-form input {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  color: #f8fafc;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  font-size: 0.95rem;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.api-form input:focus {
+  outline: none;
+  border-color: rgba(59, 130, 246, 0.6);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}
+
+.api-form .form-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.api-endpoints {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.api-endpoint {
+  background: rgba(30, 41, 59, 0.6);
+  border-radius: 14px;
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.api-endpoint-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-family: 'Fira Code', 'JetBrains Mono', monospace;
+}
+
+.api-method {
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.api-method.get {
+  background: rgba(34, 197, 94, 0.15);
+  color: #4ade80;
+  border: 1px solid rgba(34, 197, 94, 0.35);
+}
+
+.api-path {
+  color: #f8fafc;
+  font-weight: 600;
+}
+
+.api-endpoint-description {
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+.api-endpoint pre {
+  margin: 0;
+  background: rgba(15, 23, 42, 0.7);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  overflow-x: auto;
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+
+.api-snippet {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.api-snippet-label {
+  color: #94a3b8;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.api-snippet pre {
+  margin: 0;
+  background: rgba(15, 23, 42, 0.7);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  overflow-x: auto;
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+
+.api-data-panels {
+  display: grid;
+  gap: 1.25rem;
+}
+
+@media (min-width: 768px) {
+  .api-data-panels {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.api-data-card {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  border-radius: 14px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.api-data-card h4 {
+  margin: 0;
+  font-size: 1rem;
+  color: #e2e8f0;
+}
+
+.api-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.api-list-item {
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  background: rgba(30, 41, 59, 0.5);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.api-list-empty {
+  color: #64748b;
+  font-style: italic;
+}
+
+.api-item-title {
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.api-item-meta {
+  color: #94a3b8;
+  font-size: 0.85rem;
+}
+
+.api-user-role {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #38bdf8;
+  text-transform: uppercase;
+  margin-left: 0.25rem;
+}
+
 /* Mobile Responsive */
 /* Barra de navegación móvil exclusiva */
 .mobile-bottom-nav {

--- a/resources/views/partials/profile/_section-api.blade.php
+++ b/resources/views/partials/profile/_section-api.blade.php
@@ -1,0 +1,112 @@
+<div class="content-section" id="section-apikey" style="display: none;">
+    <div class="info-card api-card">
+        <h2 class="card-title">
+            <span class="card-icon">🔐</span>
+            API de Juntify
+        </h2>
+        <p class="api-intro">
+            Integra tus aplicaciones con Juntify para consultar reuniones, tareas y usuarios de forma segura.
+            Sigue la guía paso a paso para autenticarte, guardar tu token y consumir los endpoints disponibles.
+        </p>
+
+        <div class="api-status-panel">
+            <div>
+                <span id="api-connection-status" class="api-status-badge api-status--disconnected">Sin conectar</span>
+                <p class="api-status-help">Inicia sesión para generar un token y habilitar las consultas desde este panel.</p>
+            </div>
+            <div class="api-token-wrapper">
+                <span class="api-token-label">Token activo</span>
+                <code id="api-token-value" class="api-token-value">No has iniciado sesión aún.</code>
+                <div class="api-token-actions">
+                    <button type="button" class="btn btn-secondary" id="api-copy-token" disabled>Copiar token</button>
+                    <button type="button" class="btn btn-danger" id="api-logout-btn" disabled>Revocar token</button>
+                </div>
+            </div>
+        </div>
+
+        <div class="api-sections-grid">
+            <section class="api-section">
+                <h3>Paso 1: Autenticación</h3>
+                <p class="api-text">Utiliza tus credenciales de Juntify para generar un token personal. Puedes hacerlo desde este formulario o vía API.</p>
+                <form id="api-login-form" class="api-form" autocomplete="off">
+                    <div class="form-row">
+                        <label for="api-login-email">Correo electrónico</label>
+                        <input type="email" id="api-login-email" name="email" placeholder="tu-correo@empresa.com" required>
+                    </div>
+                    <div class="form-row">
+                        <label for="api-login-password">Contraseña</label>
+                        <input type="password" id="api-login-password" name="password" placeholder="••••••••" required>
+                    </div>
+                    <div class="form-actions">
+                        <button type="submit" class="btn btn-primary" id="api-login-submit">Generar token</button>
+                    </div>
+                </form>
+                <div class="api-snippet">
+                    <span class="api-snippet-label">Ejemplo con cURL</span>
+                    <pre><code>curl -X POST https://tuservidor.com/api/integrations/login \&#10;  -H "Content-Type: application/json" \&#10;  -d '{"email":"tu-correo@empresa.com","password":"tu-contraseña"}'</code></pre>
+                </div>
+            </section>
+
+            <section class="api-section">
+                <h3>Paso 2: Consumir la API</h3>
+                <p class="api-text">Incluye el token en el encabezado <code>Authorization: Bearer &lt;token&gt;</code> para acceder a los recursos.</p>
+                <div class="api-endpoints">
+                    <article class="api-endpoint">
+                        <div class="api-endpoint-header">
+                            <span class="api-method get">GET</span>
+                            <span class="api-path">/api/integrations/meetings</span>
+                        </div>
+                        <p class="api-endpoint-description">Lista las últimas reuniones creadas por el usuario autenticado.</p>
+                        <pre><code>curl https://tuservidor.com/api/integrations/meetings \&#10;  -H "Authorization: Bearer &lt;token&gt;"</code></pre>
+                    </article>
+                    <article class="api-endpoint">
+                        <div class="api-endpoint-header">
+                            <span class="api-method get">GET</span>
+                            <span class="api-path">/api/integrations/tasks</span>
+                        </div>
+                        <p class="api-endpoint-description">Devuelve tus tareas recientes y las asociadas a tus reuniones.</p>
+                        <pre><code>curl "https://tuservidor.com/api/integrations/tasks?meeting_id=123" \&#10;  -H "Authorization: Bearer &lt;token&gt;"</code></pre>
+                    </article>
+                    <article class="api-endpoint">
+                        <div class="api-endpoint-header">
+                            <span class="api-method get">GET</span>
+                            <span class="api-path">/api/integrations/users/search</span>
+                        </div>
+                        <p class="api-endpoint-description">Busca usuarios de Juntify por nombre, correo o username.</p>
+                        <pre><code>curl "https://tuservidor.com/api/integrations/users/search?query=mar" \&#10;  -H "Authorization: Bearer &lt;token&gt;"</code></pre>
+                    </article>
+                </div>
+            </section>
+
+            <section class="api-section">
+                <h3>Paso 3: Consultas desde el panel</h3>
+                <p class="api-text">Una vez que hayas iniciado sesión, podrás visualizar rápidamente tus reuniones y tareas, además de buscar usuarios.</p>
+                <div id="api-data-panels" class="api-data-panels" style="display: none;">
+                    <div class="api-data-card">
+                        <h4>Reuniones recientes</h4>
+                        <ul id="api-meetings-list" class="api-list">
+                            <li class="api-list-empty">Inicia sesión para ver tus reuniones.</li>
+                        </ul>
+                    </div>
+                    <div class="api-data-card">
+                        <h4>Tareas asociadas</h4>
+                        <ul id="api-tasks-list" class="api-list">
+                            <li class="api-list-empty">Inicia sesión para listar tus tareas.</li>
+                        </ul>
+                    </div>
+                </div>
+
+                <form id="api-user-search-form" class="api-form api-form-inline">
+                    <div class="form-row">
+                        <label for="api-user-search-input">Buscar usuarios</label>
+                        <input type="text" id="api-user-search-input" name="query" placeholder="Escribe al menos 2 caracteres" minlength="2">
+                    </div>
+                    <div class="form-actions">
+                        <button type="submit" class="btn btn-secondary">Buscar</button>
+                    </div>
+                </form>
+                <ul id="api-user-search-results" class="api-list"></ul>
+            </section>
+        </div>
+    </div>
+</div>

--- a/resources/views/partials/profile/_sidebar.blade.php
+++ b/resources/views/partials/profile/_sidebar.blade.php
@@ -37,6 +37,15 @@
                 </a>
             </li>
             <li class="nav-item">
+                <a href="#" class="nav-link" data-section="apikey">
+                    <svg class="nav-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 5.25a3.75 3.75 0 11-5.5 3.3L6 12.75V15h2.25l2.739-2.739a3.75 3.75 0 014.761 5.722" />
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M18 15.75a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z" />
+                    </svg>
+                    API Key
+                </a>
+            </li>
+            <li class="nav-item">
                 <a href="#" class="nav-link" data-section="purchases">
                     <svg class="nav-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 2.25h1.386c.51 0 .96.36 1.07.86l.507 2.454a.563.563 0 00.55.436h11.614a.563.563 0 00.551-.436L19.294 3.11a1.125 1.125 0 011.07-.86H21.75M5.25 12.75h14.25m-14.25 0l-.75 3.75m0 0h15.75m-15.75 0L5.25 21m0 0a1.5 1.5 0 103 0m10.5 0a1.5 1.5 0 103 0" />

--- a/resources/views/profile.blade.php
+++ b/resources/views/profile.blade.php
@@ -110,6 +110,7 @@
             @include('partials.profile._section-info')
             @include('partials.profile._section-connect', ['folder' => $folder, 'subfolders' => $subfolders, 'folderMessage' => $folderMessage])
             @include('partials.profile._section-plans')
+            @include('partials.profile._section-api')
             @include('partials.profile._section-other')
 
         </main>


### PR DESCRIPTION
## Summary
- add persistent API tokens with migration, model, and middleware to secure integration requests
- expose login, session, meetings, tasks, and user search endpoints under a new /api/integrations namespace
- extend the profile with an API Key sidebar entry, interactive documentation panel, and supporting styling/scripts

## Testing
- `php artisan test` *(fails: vendor/autoload.php is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e578f4450483239021ab0beac8e8cd