### PR TITLE
Allow generating integration tokens without re-authentication

### DIFF
--- a/resources/views/partials/profile/_section-api.blade.php
+++ b/resources/views/partials/profile/_section-api.blade.php
@@ -6,7 +6,7 @@
         </h2>
         <p class="api-intro">
             Integra tus aplicaciones con Juntify para consultar reuniones, tareas y usuarios de forma segura.
-            Sigue la guía paso a paso para autenticarte, guardar tu token y consumir los endpoints disponibles.
+            Genera tu token personal desde este panel y reutilízalo en tus integraciones externas.
         </p>
 
         <div class="api-docs-cta">
@@ -15,13 +15,14 @@
 
         <div class="api-status-panel">
             <div>
-                <span id="api-connection-status" class="api-status-badge api-status--disconnected">Sin conectar</span>
-                <p class="api-status-help">Inicia sesión para generar un token y habilitar las consultas desde este panel.</p>
+                <span id="api-connection-status" class="api-status-badge api-status--disconnected">Sin token activo</span>
+                <p class="api-status-help">Con tu sesión iniciada puedes generar un token y habilitar las consultas desde este panel.</p>
             </div>
             <div class="api-token-wrapper">
                 <span class="api-token-label">Token activo</span>
-                <code id="api-token-value" class="api-token-value">No has iniciado sesión aún.</code>
+                <code id="api-token-value" class="api-token-value">Aún no has generado un token desde este dispositivo.</code>
                 <div class="api-token-actions">
+                    <button type="button" class="btn btn-primary" id="api-generate-token">Generar token</button>
                     <button type="button" class="btn btn-secondary" id="api-copy-token" disabled>Copiar token</button>
                     <button type="button" class="btn btn-danger" id="api-logout-btn" disabled>Revocar token</button>
                 </div>
@@ -30,29 +31,23 @@
 
         <div class="api-sections-grid">
             <section class="api-section">
-                <h3>Paso 1: Autenticación</h3>
-                <p class="api-text">Utiliza tus credenciales de Juntify para generar un token personal. Puedes hacerlo desde este formulario o vía API.</p>
-                <form id="api-login-form" class="api-form" autocomplete="off">
-                    <div class="form-row">
-                        <label for="api-login-email">Correo electrónico</label>
-                        <input type="email" id="api-login-email" name="email" placeholder="tu-correo@empresa.com" required>
-                    </div>
-                    <div class="form-row">
-                        <label for="api-login-password">Contraseña</label>
-                        <input type="password" id="api-login-password" name="password" placeholder="••••••••" required>
-                    </div>
-                    <div class="form-actions">
-                        <button type="submit" class="btn btn-primary" id="api-login-submit">Generar token</button>
-                    </div>
-                </form>
+                <h3>Gestiona tu token</h3>
+                <p class="api-text">
+                    Estando autenticado en Juntify puedes generar un token personal con un clic. El token se almacena de forma
+                    local para que puedas probar los endpoints y revocarlo cuando ya no lo necesites.
+                </p>
+                <p class="api-text">
+                    Si necesitas crear tokens desde otra aplicación (por ejemplo, tu propio panel), utiliza el endpoint de
+                    autenticación descrito en la documentación.
+                </p>
                 <div class="api-snippet">
-                    <span class="api-snippet-label">Ejemplo con cURL</span>
+                    <span class="api-snippet-label">Generar token vía API</span>
                     <pre><code>curl -X POST https://tuservidor.com/api/integrations/login \&#10;  -H "Content-Type: application/json" \&#10;  -d '{"email":"tu-correo@empresa.com","password":"tu-contraseña"}'</code></pre>
                 </div>
             </section>
 
             <section class="api-section">
-                <h3>Paso 2: Consumir la API</h3>
+                <h3>Consume la API</h3>
                 <p class="api-text">Incluye el token en el encabezado <code>Authorization: Bearer &lt;token&gt;</code> para acceder a los recursos.</p>
                 <div class="api-endpoints">
                     <article class="api-endpoint">
@@ -83,19 +78,19 @@
             </section>
 
             <section class="api-section">
-                <h3>Paso 3: Consultas desde el panel</h3>
-                <p class="api-text">Una vez que hayas iniciado sesión, podrás visualizar rápidamente tus reuniones y tareas, además de buscar usuarios.</p>
+                <h3>Pruebas rápidas</h3>
+                <p class="api-text">Cuando generes tu token podrás visualizar tus reuniones y tareas recientes directamente desde este panel.</p>
                 <div id="api-data-panels" class="api-data-panels" style="display: none;">
                     <div class="api-data-card">
                         <h4>Reuniones recientes</h4>
                         <ul id="api-meetings-list" class="api-list">
-                            <li class="api-list-empty">Inicia sesión para ver tus reuniones.</li>
+                            <li class="api-list-empty">Genera tu token para ver tus reuniones.</li>
                         </ul>
                     </div>
                     <div class="api-data-card">
                         <h4>Tareas asociadas</h4>
                         <ul id="api-tasks-list" class="api-list">
-                            <li class="api-list-empty">Inicia sesión para listar tus tareas.</li>
+                            <li class="api-list-empty">Genera tu token para listar tus tareas.</li>
                         </ul>
                     </div>
                 </div>

--- a/resources/views/profile/documentation.blade.php
+++ b/resources/views/profile/documentation.blade.php
@@ -59,21 +59,21 @@
             <section class="doc-card" aria-labelledby="api-key-title" id="api-key">
                 <h2 id="api-key-title">🔐 Uso de API Key</h2>
                 <p>
-                    Inicia sesión con tu cuenta de Juntify para generar un token personal. Este token se almacena en tu
-                    navegador y puedes revocarlo en cualquier momento. Utilízalo como credencial <code>Bearer</code>
-                    en cada petición a la API.
+                    Con una sesión activa en Juntify puedes generar tu token personal directamente desde tu perfil. El token
+                    queda disponible para probar los endpoints desde esta documentación y puedes revocarlo cuando lo necesites.
                 </p>
 
                 <div class="api-panel" id="doc-api-section">
                     <div class="api-status">
                         <div>
-                            <span id="api-connection-status" class="api-status-badge api-status--disconnected">Sin conectar</span>
-                            <p class="api-status-help">Autentícate con tus credenciales para habilitar las consultas.</p>
+                            <span id="api-connection-status" class="api-status-badge api-status--disconnected">Sin token activo</span>
+                            <p class="api-status-help">Genera un token desde tu perfil o con el botón siguiente y úsalo en tus integraciones.</p>
                         </div>
                         <div class="api-token-wrapper">
                             <span class="api-token-label">Token activo</span>
-                            <code id="api-token-value" class="api-token-value">No has iniciado sesión aún.</code>
+                            <code id="api-token-value" class="api-token-value">Aún no has generado un token desde este navegador.</code>
                             <div class="api-token-actions">
+                                <button type="button" class="btn btn-primary" id="api-generate-token">Generar token</button>
                                 <button type="button" class="btn btn-secondary" id="api-copy-token" disabled>Copiar token</button>
                                 <button type="button" class="btn btn-danger" id="api-logout-btn" disabled>Revocar token</button>
                             </div>
@@ -82,22 +82,15 @@
 
                     <div class="doc-grid columns-3">
                         <article>
-                            <h3>Paso 1 · Autenticación</h3>
-                            <p>Introduce tu correo y contraseña para recibir un token seguro asociado a tu cuenta.</p>
-                            <form id="api-login-form" class="api-form" autocomplete="off">
-                                <div class="form-row">
-                                    <label for="api-login-email">Correo electrónico</label>
-                                    <input type="email" id="api-login-email" name="email" placeholder="tu-correo@empresa.com" required>
-                                </div>
-                                <div class="form-row">
-                                    <label for="api-login-password">Contraseña</label>
-                                    <input type="password" id="api-login-password" name="password" placeholder="••••••••" required>
-                                </div>
-                                <div class="api-token-actions">
-                                    <button type="submit" class="btn btn-primary" id="api-login-submit">Generar token</button>
-                                    <a href="{{ route('password.forgot') }}" class="btn btn-outline">¿Olvidaste tu contraseña?</a>
-                                </div>
-                            </form>
+                            <h3>Generar y custodiar tu token</h3>
+                            <p>
+                                Usa el botón anterior para obtener un token inmediato utilizando tu sesión actual. Guarda el valor en un gestor
+                                seguro y, si lo utilizas en producción, revoca los tokens que ya no necesites.
+                            </p>
+                            <p>
+                                ¿Necesitas emitirlo desde otra aplicación? Realiza una petición al endpoint de autenticación con las credenciales
+                                del usuario que integrará Juntify.
+                            </p>
                             <div class="code-block">
                                 <pre><code>curl -X POST {{ url('/api/integrations/login') }} \
   -H "Content-Type: application/json" \
@@ -106,7 +99,7 @@
                         </article>
 
                         <article>
-                            <h3>Paso 2 · Consumir la API</h3>
+                            <h3>Consumir la API</h3>
                             <p>Envía el token en el encabezado <code>Authorization: Bearer &lt;token&gt;</code> para acceder a tus recursos.</p>
                             <div class="code-block">
                                 <pre><code>fetch('{{ url('/api/integrations/meetings') }}', {
@@ -121,20 +114,20 @@
                                 <div class="api-data-card">
                                     <h4>Reuniones recientes</h4>
                                     <ul id="api-meetings-list" class="api-list">
-                                        <li class="api-list-empty">Inicia sesión para ver tus reuniones.</li>
+                                        <li class="api-list-empty">Genera tu token para ver tus reuniones.</li>
                                     </ul>
                                 </div>
                                 <div class="api-data-card">
                                     <h4>Tareas vinculadas</h4>
                                     <ul id="api-tasks-list" class="api-list">
-                                        <li class="api-list-empty">Inicia sesión para listar tus tareas.</li>
+                                        <li class="api-list-empty">Genera tu token para listar tus tareas.</li>
                                     </ul>
                                 </div>
                             </div>
                         </article>
 
                         <article>
-                            <h3>Paso 3 · Buscar usuarios</h3>
+                            <h3>Buscar usuarios</h3>
                             <p>Realiza consultas puntuales desde el panel para validar tu integración.</p>
                             <form id="api-user-search-form" class="api-form api-form-inline">
                                 <div class="form-row">

--- a/routes/api.php
+++ b/routes/api.php
@@ -218,6 +218,9 @@ Route::middleware('auth')->post('/create-token', function (Request $request) {
 
 Route::prefix('integrations')->group(function () {
     Route::post('/login', [IntegrationAuthController::class, 'login'])->middleware('throttle:10,1');
+    Route::post('/token', [IntegrationAuthController::class, 'createFromSession'])
+        ->middleware(['web', 'auth'])
+        ->name('api.integrations.token');
 
     Route::middleware('api.token')->group(function () {
         Route::get('/me', [IntegrationAuthController::class, 'me']);

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,6 +19,8 @@ export default defineConfig({
                 'resources/js/index.js',
                 'resources/css/profile.css',
                 'resources/js/profile.js',
+                'resources/css/profile-documentation.css',
+                'resources/js/profile-documentation.js',
                 'resources/css/auth/login.css',
                 'resources/js/auth/login.js',
                 'resources/css/auth/register.css',


### PR DESCRIPTION
## Summary
- add a session-protected endpoint to issue integration API tokens without re-entering credentials
- update the profile API section and documentation to generate, copy, and revoke tokens with the active session
- register the documentation assets with Vite so the manifest includes the required CSS and JavaScript

## Testing
- php artisan test *(fails: missing `vendor/autoload.php`)*

------
https://chatgpt.com/codex/tasks/task_e_68e58545f8b08323b2235d57448ac0d0