### PR TITLE
Remove API helper cards from profile view

### DIFF
--- a/resources/views/partials/profile/_section-api.blade.php
+++ b/resources/views/partials/profile/_section-api.blade.php
@@ -29,83 +29,11 @@
             </div>
         </div>
 
-        <div class="api-sections-grid">
-            <section class="api-section">
-                <h3>Gestiona tu token</h3>
-                <p class="api-text">
-                    Estando autenticado en Juntify puedes generar un token personal con un clic. El token se almacena de forma
-                    local para que puedas probar los endpoints y revocarlo cuando ya no lo necesites.
-                </p>
-                <p class="api-text">
-                    Si necesitas crear tokens desde otra aplicación (por ejemplo, tu propio panel), utiliza el endpoint de
-                    autenticación descrito en la documentación.
-                </p>
-                <div class="api-snippet">
-                    <span class="api-snippet-label">Generar token vía API</span>
-                    <pre><code>curl -X POST https://tuservidor.com/api/integrations/login \&#10;  -H "Content-Type: application/json" \&#10;  -d '{"email":"tu-correo@empresa.com","password":"tu-contraseña"}'</code></pre>
-                </div>
-            </section>
-
-            <section class="api-section">
-                <h3>Consume la API</h3>
-                <p class="api-text">Incluye el token en el encabezado <code>Authorization: Bearer &lt;token&gt;</code> para acceder a los recursos.</p>
-                <div class="api-endpoints">
-                    <article class="api-endpoint">
-                        <div class="api-endpoint-header">
-                            <span class="api-method get">GET</span>
-                            <span class="api-path">/api/integrations/meetings</span>
-                        </div>
-                        <p class="api-endpoint-description">Lista las últimas reuniones creadas por el usuario autenticado.</p>
-                        <pre><code>curl https://tuservidor.com/api/integrations/meetings \&#10;  -H "Authorization: Bearer &lt;token&gt;"</code></pre>
-                    </article>
-                    <article class="api-endpoint">
-                        <div class="api-endpoint-header">
-                            <span class="api-method get">GET</span>
-                            <span class="api-path">/api/integrations/tasks</span>
-                        </div>
-                        <p class="api-endpoint-description">Devuelve tus tareas recientes y las asociadas a tus reuniones.</p>
-                        <pre><code>curl "https://tuservidor.com/api/integrations/tasks?meeting_id=123" \&#10;  -H "Authorization: Bearer &lt;token&gt;"</code></pre>
-                    </article>
-                    <article class="api-endpoint">
-                        <div class="api-endpoint-header">
-                            <span class="api-method get">GET</span>
-                            <span class="api-path">/api/integrations/users/search</span>
-                        </div>
-                        <p class="api-endpoint-description">Busca usuarios de Juntify por nombre, correo o username.</p>
-                        <pre><code>curl "https://tuservidor.com/api/integrations/users/search?query=mar" \&#10;  -H "Authorization: Bearer &lt;token&gt;"</code></pre>
-                    </article>
-                </div>
-            </section>
-
-            <section class="api-section">
-                <h3>Pruebas rápidas</h3>
-                <p class="api-text">Cuando generes tu token podrás visualizar tus reuniones y tareas recientes directamente desde este panel.</p>
-                <div id="api-data-panels" class="api-data-panels" style="display: none;">
-                    <div class="api-data-card">
-                        <h4>Reuniones recientes</h4>
-                        <ul id="api-meetings-list" class="api-list">
-                            <li class="api-list-empty">Genera tu token para ver tus reuniones.</li>
-                        </ul>
-                    </div>
-                    <div class="api-data-card">
-                        <h4>Tareas asociadas</h4>
-                        <ul id="api-tasks-list" class="api-list">
-                            <li class="api-list-empty">Genera tu token para listar tus tareas.</li>
-                        </ul>
-                    </div>
-                </div>
-
-                <form id="api-user-search-form" class="api-form api-form-inline">
-                    <div class="form-row">
-                        <label for="api-user-search-input">Buscar usuarios</label>
-                        <input type="text" id="api-user-search-input" name="query" placeholder="Escribe al menos 2 caracteres" minlength="2">
-                    </div>
-                    <div class="form-actions">
-                        <button type="submit" class="btn btn-secondary">Buscar</button>
-                    </div>
-                </form>
-                <ul id="api-user-search-results" class="api-list"></ul>
-            </section>
+        <div class="api-info">
+            <p class="api-text">
+                Consulta la documentación para conocer todos los endpoints disponibles y cómo integrarlos con tus
+                aplicaciones.
+            </p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- remove the extra API helper cards from the profile API key section
- leave a concise note pointing users to the API documentation instead

## Testing
- `php artisan serve --host=0.0.0.0 --port=8000` *(fails: missing vendor directory in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e58f7099048323b2f81ac7bd6a8bb6