### PR TITLE
Fix notifications panel stacking on profile

### DIFF
--- a/resources/views/components/notifications.blade.php
+++ b/resources/views/components/notifications.blade.php
@@ -15,6 +15,10 @@
 <style>
 /* Panel styling */
 .notifications-panel.notifications-panel--styled {
+    position: fixed;
+    top: 72px;
+    right: 1rem;
+    z-index: 9999;
     background: rgba(15,23,42,0.92); /* slate-900 with opacity */
     backdrop-filter: blur(8px);
     -webkit-backdrop-filter: blur(8px);


### PR DESCRIPTION
## Summary
- ensure the notifications dropdown panel uses a fixed position with a high z-index so it renders above the navbar on the profile page
- keep default offsets so the panel aligns correctly even before JavaScript adjustments

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e594a89ff483238297ea5fe0b6cfdd