### PR TITLE
Allow credentials in CORS configuration for integration token requests

### DIFF
--- a/config/cors.php
+++ b/config/cors.php
@@ -19,7 +19,9 @@ return [
 
     'allowed_methods' => ['*'],
 
-    'allowed_origins' => ['*'],
+    'allowed_origins' => array_values(array_filter(array_map('trim', explode(',', env('CORS_ALLOWED_ORIGINS',
+        'https://app.juntify.com,https://demo.juntify.com,http://localhost:5173,http://localhost:3000'
+    ))))),
 
     'allowed_origins_patterns' => [],
 
@@ -29,6 +31,6 @@ return [
 
     'max_age' => 0,
 
-    'supports_credentials' => false,
+    'supports_credentials' => env('CORS_SUPPORTS_CREDENTIALS', true),
 
 ];


### PR DESCRIPTION
## Summary
- allow configuring the CORS allowed origins via the CORS_ALLOWED_ORIGINS environment variable
- enable credentialed CORS requests so session-based integration token calls include cookies

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5ab208dbc8323a968a0cadbb59f5e