### PR TITLE
Avoid bcrypt check on non-bcrypt passwords

### DIFF
--- a/app/Http/Controllers/Api/IntegrationAuthController.php
+++ b/app/Http/Controllers/Api/IntegrationAuthController.php
@@ -70,7 +70,10 @@ class IntegrationAuthController extends Controller
             }
 
             // Compatibilidad con hashes generados por Hash::make
-            if (!$passwordIsValid) {
+            if (
+                !$passwordIsValid
+                && $this->looksLikeBcryptHash((string) $user->password)
+            ) {
                 $passwordIsValid = Hash::check($providedPassword, $user->password);
             }
         }


### PR DESCRIPTION
## Summary
- guard the API integration login from calling Hash::check when the stored password is not a bcrypt hash, preventing runtime exceptions

## Testing
- php artisan test *(fails: vendor dependencies are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5b4f14b588323acca8251061d6a87