### PR TITLE
Expose raw JU payload and support tokenized audio streams

### DIFF
--- a/tests/Feature/Integration/IntegrationDataControllerTest.php
+++ b/tests/Feature/Integration/IntegrationDataControllerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use App\Models\ApiToken;
+use App\Models\User;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+
+it('returns integration meeting details with tokenized stream url and raw ju data', function () {
+    Storage::fake('local');
+
+    $juData = [
+        'summary' => 'Resumen de prueba',
+        'key_points' => ['Primer punto', 'Segundo punto'],
+        'tasks' => [
+            ['title' => 'Enviar follow-up', 'owner' => 'Ana'],
+        ],
+        'transcription' => 'Texto completo de la reunión.',
+        'speakers' => [['name' => 'Ana']],
+        'segments' => [
+            ['speaker' => 'Ana', 'text' => 'Hola a todos', 'start' => 0, 'end' => 5],
+        ],
+    ];
+
+    Http::fake([
+        'https://example.test/transcript.ju' => Http::response(json_encode($juData), 200, [
+            'Content-Type' => 'application/json',
+        ]),
+        'https://example.test/audio.ogg' => Http::response('AUDIO', 200, [
+            'Content-Type' => 'audio/ogg',
+            'Content-Disposition' => 'attachment; filename="audio.ogg"',
+        ]),
+    ]);
+
+    $user = User::factory()->create([
+        'username' => 'integration-user',
+    ]);
+
+    $meeting = createLegacyMeeting($user, [
+        'audio_drive_id' => null,
+        'transcript_drive_id' => null,
+        'audio_download_url' => 'https://example.test/audio.ogg',
+        'transcript_download_url' => 'https://example.test/transcript.ju',
+    ]);
+
+    $plainToken = 'plain-api-token';
+    ApiToken::create([
+        'user_id' => $user->id,
+        'name' => 'Test Token',
+        'token_hash' => ApiToken::hashToken($plainToken),
+        'abilities' => ['meetings:read'],
+    ]);
+
+    $response = $this->withHeaders([
+        'Authorization' => 'Bearer ' . $plainToken,
+    ])->getJson('/api/integrations/meetings/' . $meeting->id);
+
+    $response->assertOk();
+
+    $data = $response->json('data');
+
+    expect($data['audio']['stream_url'])
+        ->toContain('/api/integrations/meetings/' . $meeting->id . '/audio')
+        ->and($data['audio']['stream_url'])
+        ->toContain('api_token=' . $plainToken);
+
+    expect($data['ju']['raw'])
+        ->toMatchArray($juData);
+
+    expect($data['ju']['needs_encryption'])->toBeTrue();
+});
+
+it('streams meeting audio when api token is provided via query parameter', function () {
+    Storage::fake('local');
+
+    Http::fake([
+        'https://example.test/audio.ogg' => Http::response('AUDIOBYTES', 200, [
+            'Content-Type' => 'audio/ogg',
+            'Content-Disposition' => 'inline; filename="stream.ogg"',
+        ]),
+    ]);
+
+    $user = User::factory()->create([
+        'username' => 'stream-user',
+    ]);
+
+    $meeting = createLegacyMeeting($user, [
+        'audio_drive_id' => null,
+        'audio_download_url' => 'https://example.test/audio.ogg',
+        'transcript_drive_id' => null,
+        'transcript_download_url' => null,
+    ]);
+
+    $plainToken = 'query-token';
+    ApiToken::create([
+        'user_id' => $user->id,
+        'name' => 'Stream Token',
+        'token_hash' => ApiToken::hashToken($plainToken),
+    ]);
+
+    $response = $this->get('/api/integrations/meetings/' . $meeting->id . '/audio?api_token=' . $plainToken);
+
+    $response->assertOk();
+    $response->assertHeader('Content-Type', 'audio/ogg');
+    expect($response->headers->get('Content-Disposition'))->toContain('stream.ogg');
+    expect($response->getContent())->toBe('AUDIOBYTES');
+});

--- a/tools/INTEGRATION_API_README.md
+++ b/tools/INTEGRATION_API_README.md
@@ -83,7 +83,8 @@ Respuesta 200:
       "tasks": [{"title": "Enviar propuesta", "owner": "María"}],
       "transcription": "Texto completo...",
       "speakers": [{"name": "Orador 1"}],
-      "segments": [{"speaker": "Orador 1", "text": "Hola"}]
+      "segments": [{"speaker": "Orador 1", "text": "Hola"}],
+      "raw": {"summary": "Resumen de la reunión...", "key_points": ["Punto 1"], "tasks": []}
     },
     "audio": {
       "available": true,
@@ -91,19 +92,20 @@ Respuesta 200:
       "filename": "demo_cliente.mp3",
       "mime_type": "audio/mpeg",
       "size_bytes": 10485760,
-      "stream_url": "https://app.juntify.com/api/integrations/meetings/1234/audio"
+      "stream_url": "https://app.juntify.com/api/integrations/meetings/1234/audio?api_token={token}"
     }
   }
 }
 ```
 
 * `ju.available` indica si se pudo obtener y desencriptar el archivo `.ju`.
-* `audio.stream_url` se usa para reproducir/descargar el audio directamente desde la API.
+* `ju.raw` contiene el JSON desencriptado original del `.ju` para usos avanzados.
+* `audio.stream_url` se usa para reproducir/descargar el audio directamente desde la API. Incluye el `api_token` en la query string para permitir el uso en etiquetas `<audio>` u otros consumidores sin cabeceras.
 
 ### Descargar audio de la reunión
 ```http
-GET /api/integrations/meetings/{meetingId}/audio
-Authorization: Bearer {token}
+GET /api/integrations/meetings/{meetingId}/audio?api_token={token}
+Authorization: Bearer {token} (opcional si ya enviaste `api_token`)
 Accept: audio/*
 ```
 Devuelve el flujo binario (`Content-Type` según el archivo original). Usa este endpoint para


### PR DESCRIPTION
## Summary
- append the caller token to the integration audio stream URL so clients without auth headers can play the audio
- expose the decrypted JU payload in integration responses and persist it via the cache helper
- document the new behaviour and cover it with feature tests for the integration API

## Testing
- php artisan test --testsuite=Feature --filter=IntegrationDataControllerTest *(fails: vendor/autoload.php is missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5bffdace8832381f67eca879cdf77