### PR TITLE
Improve API token UX when session expired

### DIFF
--- a/resources/js/integrations/api-key.js
+++ b/resources/js/integrations/api-key.js
@@ -294,11 +294,16 @@ export function initApiIntegrationSection(rootId = 'section-apikey') {
         setDisconnectedState();
       }
     } catch (error) {
-      const message = error.response?.data?.message
-        ?? error.response?.data?.errors?.device_name?.[0]
-        ?? 'No se pudo generar el token.';
-      showErrorMessage(message);
-      setDisconnectedState();
+      if (error.response?.status === 401) {
+        showErrorMessage('Tu sesión de Juntify expiró en este navegador. Inicia sesión nuevamente y recarga la página para generar un token.');
+        setDisconnectedState('Debes iniciar sesión en Juntify para emitir un token desde este panel.');
+      } else {
+        const message = error.response?.data?.message
+          ?? error.response?.data?.errors?.device_name?.[0]
+          ?? 'No se pudo generar el token.';
+        showErrorMessage(message);
+        setDisconnectedState();
+      }
     }
 
     generateBtn.disabled = false;

--- a/resources/views/profile/documentation.blade.php
+++ b/resources/views/profile/documentation.blade.php
@@ -240,7 +240,7 @@ Authorization: Bearer {{ '{token}' }}
                         <section class="doc-card" id="errors">
                             <h2>⚠️ Errores comunes</h2>
                             <ul class="list-disc list-inside space-y-2 text-sm text-slate-300">
-                                <li><code>401 Unauthorized</code>: el token es inválido o expiró. Renueva el token o ejecuta <code>/login</code> nuevamente.</li>
+                                <li><code>401 Unauthorized</code>: el token es inválido, expiró o tu sesión del navegador caducó. Si ves el mensaje "Unauthenticated" al generar un token, inicia sesión en Juntify en otra pestaña, actualiza esta página y vuelve a intentarlo.</li>
                                 <li><code>404 Not Found</code>: el recurso no pertenece al usuario autenticado o ya no está disponible.</li>
                                 <li><code>429 Too Many Requests</code>: se alcanzó el límite de peticiones. Implementa reintentos con backoff exponencial.</li>
                             </ul>


### PR DESCRIPTION
## Summary
- show a clear session-expired message when generating an API token without an active login
- document the 401 error path in the API documentation so users know to refresh their session

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5c503fa848323aa9ae68820439edf