### PR TITLE
Handle Argon hashed integration logins

### DIFF
--- a/tests/Feature/Integration/IntegrationAuthControllerTest.php
+++ b/tests/Feature/Integration/IntegrationAuthControllerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+
+it('allows integrations login for users with argon hashed passwords', function () {
+    $password = 'SuperSecure123!';
+
+    $user = User::factory()->create([
+        'password' => Hash::driver('argon')->make($password),
+    ]);
+
+    $response = $this->postJson('/api/integrations/login', [
+        'email' => $user->email,
+        'password' => $password,
+        'device_name' => 'Integrations Test Device',
+    ]);
+
+    $response->assertCreated();
+
+    $response->assertJsonStructure([
+        'token',
+        'token_type',
+        'abilities',
+        'created_at',
+        'user' => [
+            'id',
+            'username',
+            'full_name',
+            'email',
+            'role',
+        ],
+    ]);
+
+    $this->assertDatabaseHas('api_tokens', [
+        'user_id' => $user->id,
+        'name' => 'Integrations Test Device',
+    ]);
+});


### PR DESCRIPTION
## Summary
- add a password verification helper that gracefully falls back to PHP's password verifier when the stored hash is not bcrypt
- ensure integration logins still work for users stored with Argon hashes by covering the workflow with a feature test

## Testing
- ⚠️ `composer install` *(fails: GitHub API returned 403 while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e5e543f84483239b8d590854732e49