### PR TITLE
Fix integration token endpoint authentication

### DIFF
--- a/app/Http/Controllers/Api/IntegrationAuthController.php
+++ b/app/Http/Controllers/Api/IntegrationAuthController.php
@@ -96,7 +96,14 @@ class IntegrationAuthController extends Controller
 
     public function createFromSession(Request $request): JsonResponse
     {
-        $user = $request->user();
+        $user = $request->user('web');
+
+        if (!$user) {
+            return response()->json([
+                'message' => 'Unauthenticated.',
+                'error' => 'Token de autenticación requerido'
+            ], 401);
+        }
 
         $validated = $request->validate([
             'device_name' => 'nullable|string|max:255',

--- a/routes/api.php
+++ b/routes/api.php
@@ -219,7 +219,7 @@ Route::middleware('auth')->post('/create-token', function (Request $request) {
 Route::prefix('integrations')->group(function () {
     Route::post('/login', [IntegrationAuthController::class, 'login'])->middleware('throttle:10,1');
     Route::post('/token', [IntegrationAuthController::class, 'createFromSession'])
-        ->middleware(['web', 'auth'])
+        ->middleware(['web', 'auth:web'])
         ->name('api.integrations.token');
 
     Route::middleware('api.token')->group(function () {


### PR DESCRIPTION
## Summary
- ensure the session-based integration token endpoint authenticates explicitly with the web guard
- add a defensive JSON 401 response when the request is not associated with a logged-in web user

## Testing
- not run (composer install requires external network access)

------
https://chatgpt.com/codex/tasks/task_e_68e5e69ba26c8323a47f3dc45cd1ed39