### PR TITLE
Ensure integration token requests send session cookies

### DIFF
--- a/resources/js/integrations/api-key.js
+++ b/resources/js/integrations/api-key.js
@@ -1,5 +1,9 @@
 const INTEGRATIONS_STORAGE_KEY = 'juntifyApiToken';
 const INTEGRATIONS_BASE_URL = '/api/integrations';
+
+if (typeof axios !== 'undefined') {
+  axios.defaults.withCredentials = true;
+}
 let notificationsStyleInjected = false;
 
 function ensureNotificationStyles() {
@@ -282,6 +286,8 @@ export function initApiIntegrationSection(rootId = 'section-apikey') {
     try {
       const response = await axios.post(`${INTEGRATIONS_BASE_URL}/token`, {
         device_name: 'Panel de perfil',
+      }, {
+        withCredentials: true,
       });
 
       const token = response?.data?.token;
@@ -337,7 +343,10 @@ export function initApiIntegrationSection(rootId = 'section-apikey') {
     }
 
     try {
-      await axios.post(`${INTEGRATIONS_BASE_URL}/logout`, {}, { headers: getAuthHeaders() });
+      await axios.post(`${INTEGRATIONS_BASE_URL}/logout`, {}, {
+        headers: getAuthHeaders(),
+        withCredentials: true,
+      });
       showSuccessMessage('Token revocado con éxito.');
     } catch (error) {
       if (error.response?.status !== 401) {


### PR DESCRIPTION
## Summary
- ensure the integrations API panel always sends session cookies when requesting a token
- include credentials when revoking tokens so the session guard can authenticate the request

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5ea1d9a9c8323b24b1ad464f9375f